### PR TITLE
feat: ペルソナ発言のトークン単位ストリーミング表示

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-persona-system"
-version = "0.10.2"
+version = "0.11.0"
 description = "AIペルソナシステム - インタビューからペルソナを生成し、議論を通じてインサイトを生成"
 authors = [
     {name = "AI Persona Team"}

--- a/src/managers/agent_discussion_manager.py
+++ b/src/managers/agent_discussion_manager.py
@@ -478,9 +478,13 @@ class AgentDiscussionManager:
                     # Create prompt with round summaries + recent messages
                     # 直近10件を渡し、create_prompt_for_persona内で自分/他者/ファシリテータを分離
                     prompt = facilitator.create_prompt_for_persona(
-                        speaker, topic, all_messages[-10:],
+                        speaker,
+                        topic,
+                        all_messages[-10:],
                         round_summaries=round_summaries if round_summaries else None,
-                        latest_facilitator_message=round_summaries[-1] if round_summaries else None,
+                        latest_facilitator_message=round_summaries[-1]
+                        if round_summaries
+                        else None,
                     )
 
                     # Get persona's response (context=None, already in prompt)
@@ -516,8 +520,12 @@ class AgentDiscussionManager:
                 if round_messages:
                     try:
                         round_summary = facilitator.summarize_round(
-                            current_round, round_messages, topic,
-                            previous_summaries=round_summaries if round_summaries else None,
+                            current_round,
+                            round_messages,
+                            topic,
+                            previous_summaries=round_summaries
+                            if round_summaries
+                            else None,
                         )
 
                         # 要約を蓄積（次ラウンドのコンテキストとして使用）
@@ -731,7 +739,9 @@ class AgentDiscussionManager:
             if kb_binding:
                 kb = db_service.get_knowledge_base(kb_binding.kb_id)
                 if kb:
-                    from src.services.knowledge_base.kb_tools import create_kb_retrieval_tool
+                    from src.services.knowledge_base.kb_tools import (
+                        create_kb_retrieval_tool,
+                    )
                     from src.config import config
 
                     kb_tool = create_kb_retrieval_tool(
@@ -741,7 +751,10 @@ class AgentDiscussionManager:
                     )
                     additional_tools.append(kb_tool)
                     enhanced_prompt = self.agent_service._enhance_prompt_with_kb_info(
-                        enhanced_prompt, kb.name, kb.description, kb_binding.metadata_filters
+                        enhanced_prompt,
+                        kb.name,
+                        kb.description,
+                        kb_binding.metadata_filters,
                     )
 
         # データセット連携：ツールとプロンプト拡張を準備
@@ -939,28 +952,52 @@ class AgentDiscussionManager:
                     # Create prompt with round summaries + recent messages
                     # 直近10件を渡し、create_prompt_for_persona内で自分/他者/ファシリテータを分離
                     prompt = facilitator.create_prompt_for_persona(
-                        speaker, topic, all_messages[-10:],
+                        speaker,
+                        topic,
+                        all_messages[-10:],
                         round_summaries=round_summaries if round_summaries else None,
-                        latest_facilitator_message=round_summaries[-1] if round_summaries else None,
+                        latest_facilitator_message=round_summaries[-1]
+                        if round_summaries
+                        else None,
                     )
 
-                    # Get persona's response (context=None, already in prompt)
+                    # Get persona's response with token streaming
                     try:
-                        statement = speaker.respond(prompt, None)
+                        # Signal message start
+                        yield (
+                            "message_start",
+                            {
+                                "persona_id": speaker.get_persona_id(),
+                                "persona_name": speaker.get_persona_name(),
+                                "message_type": "statement",
+                                "round_number": current_round,
+                            },
+                        )
 
-                        # Create message for persona statement
+                        # Stream tokens
+                        full_text = ""
+                        for token in speaker.respond_streaming(prompt, None):
+                            full_text += token
+                            yield (
+                                "message_delta",
+                                {
+                                    "persona_id": speaker.get_persona_id(),
+                                    "content": token,
+                                },
+                            )
+
+                        # Create message and signal end
                         message = Message.create_new(
                             persona_id=speaker.get_persona_id(),
                             persona_name=speaker.get_persona_name(),
-                            content=statement,
+                            content=full_text,
                             message_type="statement",
                             round_number=current_round,
                         )
                         all_messages.append(message)
                         round_messages.append(message)
 
-                        # Yield the message immediately
-                        yield ("message", message)
+                        yield ("message_end", message)
 
                         self.logger.info(
                             f"Persona {speaker.get_persona_name()} spoke in round {current_round}"
@@ -976,13 +1013,38 @@ class AgentDiscussionManager:
                         spoken_in_round.append(speaker.get_persona_id())
                         continue
 
-                # ラウンド終了後にファシリテータがラウンド全体を要約
+                # ラウンド終了後にファシリテータがラウンド全体を要約（ストリーミング）
                 if round_messages:
                     try:
-                        round_summary = facilitator.summarize_round(
-                            current_round, round_messages, topic,
-                            previous_summaries=round_summaries if round_summaries else None,
+                        # Signal facilitator message start
+                        yield (
+                            "message_start",
+                            {
+                                "persona_id": "facilitator",
+                                "persona_name": "ファシリテータ",
+                                "message_type": "summary",
+                                "round_number": current_round,
+                            },
                         )
+
+                        # Stream facilitator summary tokens
+                        round_summary = ""
+                        for token in facilitator.summarize_round_streaming(
+                            current_round,
+                            round_messages,
+                            topic,
+                            previous_summaries=round_summaries
+                            if round_summaries
+                            else None,
+                        ):
+                            round_summary += token
+                            yield (
+                                "message_delta",
+                                {
+                                    "persona_id": "facilitator",
+                                    "content": token,
+                                },
+                            )
 
                         # 要約を蓄積（次ラウンドのコンテキストとして使用）
                         round_summaries.append(round_summary)
@@ -997,8 +1059,7 @@ class AgentDiscussionManager:
                         )
                         all_messages.append(summary_message)
 
-                        # Yield the summary message
-                        yield ("message", summary_message)
+                        yield ("message_end", summary_message)
 
                         self.logger.info(
                             f"Facilitator summarized round {current_round}"

--- a/src/managers/interview_manager.py
+++ b/src/managers/interview_manager.py
@@ -467,7 +467,140 @@ class InterviewManager(AgentDiscussionManager):
             self.logger.error(error_msg)
             raise InterviewAgentError(error_msg)
 
-    def save_interview_session(self, session_id: str, session_name: str | None = None) -> str:
+    def send_user_message_streaming(
+        self,
+        session_id: str,
+        message: str,
+        document_contents: Optional[List[Dict[str, Any]]] = None,
+        document_metadata: Optional[List[Dict[str, Any]]] = None,
+    ) -> Any:
+        """
+        Send a user message and stream persona responses token by token.
+
+        Yields:
+            tuple: (event_type, data)
+                - ("message_start", dict): New persona bubble
+                - ("message_delta", dict): Token chunk
+                - ("message_end", Message): Complete message
+
+        Raises:
+            InterviewSessionNotFoundError: If session not found
+            InterviewValidationError: If message validation fails
+            InterviewAgentError: If all agents fail
+        """
+        self._validate_session_exists(session_id)
+        self._validate_message_input(message)
+
+        session = self._active_sessions[session_id]
+
+        if session.is_saved:
+            error_msg = f"保存済みのセッション {session_id} では新しいメッセージを送信できません"
+            self.logger.error(error_msg)
+            raise InterviewSessionError(error_msg)
+
+        persona_agents = self._session_agents.get(session_id, [])
+
+        if not persona_agents:
+            error_msg = (
+                f"セッション {session_id} にペルソナエージェントが見つかりません"
+            )
+            self.logger.error(error_msg)
+            raise InterviewAgentError(error_msg)
+
+        # Add user message to session
+        session = session.add_user_message(message.strip())
+
+        # ドキュメントメタデータ追加
+        if document_metadata:
+            for doc_meta in document_metadata:
+                existing_docs = session.documents or []
+                is_duplicate = any(
+                    d.get("filename") == doc_meta.get("filename")
+                    and d.get("file_size") == doc_meta.get("file_size")
+                    for d in existing_docs
+                )
+                if not is_duplicate:
+                    session = session.add_document(doc_meta)
+
+        # ドキュメントコンテンツをエージェントに設定
+        if document_contents:
+            for persona_agent in persona_agents:
+                persona_agent.set_document_contents(document_contents.copy())
+
+        failed_agents: list[str] = []
+        response_count = 0
+
+        for persona_agent in persona_agents:
+            agent_name = persona_agent.get_persona_name()
+            try:
+                prompt = self._create_interview_prompt(
+                    persona_agent, message, session.messages
+                )
+
+                yield (
+                    "message_start",
+                    {
+                        "persona_id": persona_agent.get_persona_id(),
+                        "persona_name": agent_name,
+                        "message_type": "statement",
+                    },
+                )
+
+                full_text = ""
+                for token in persona_agent.respond_streaming(prompt, session.messages):
+                    full_text += token
+                    yield (
+                        "message_delta",
+                        {
+                            "persona_id": persona_agent.get_persona_id(),
+                            "content": token,
+                        },
+                    )
+
+                if not full_text.strip():
+                    raise AgentCommunicationError("Empty response from agent")
+
+                session = session.add_persona_response(
+                    persona_agent.get_persona_id(),
+                    agent_name,
+                    full_text,
+                )
+
+                response_message = Message.create_new(
+                    persona_id=persona_agent.get_persona_id(),
+                    persona_name=agent_name,
+                    content=full_text,
+                    message_type="statement",
+                )
+                yield ("message_end", response_message)
+                response_count += 1
+
+            except AgentCommunicationError as e:
+                self.logger.error(f"ペルソナ {agent_name} からの応答取得に失敗: {e}")
+                failed_agents.append(agent_name)
+                continue
+            except Exception as e:
+                self.logger.error(
+                    f"ペルソナ {agent_name} の処理中に予期しないエラー: {e}"
+                )
+                failed_agents.append(agent_name)
+                continue
+
+        if response_count == 0 and failed_agents:
+            raise InterviewAgentError(
+                f"すべてのペルソナエージェントが応答に失敗しました: {', '.join(failed_agents)}"
+            )
+
+        # Update stored session
+        self._active_sessions[session_id] = session
+
+        self.logger.info(
+            f"Streaming message processed, generated {response_count} responses"
+        )
+
+    def save_interview_session(
+        self, session_id: str, session_name: str | None = None
+    ) -> str:
         """
         Save an interview session to the database with enhanced validation and error handling.
 
@@ -733,7 +866,9 @@ class InterviewManager(AgentDiscussionManager):
             if kb_binding:
                 kb = db_service.get_knowledge_base(kb_binding.kb_id)
                 if kb:
-                    from src.services.knowledge_base.kb_tools import create_kb_retrieval_tool
+                    from src.services.knowledge_base.kb_tools import (
+                        create_kb_retrieval_tool,
+                    )
                     from src.config import config
 
                     kb_tool = create_kb_retrieval_tool(
@@ -743,7 +878,10 @@ class InterviewManager(AgentDiscussionManager):
                     )
                     additional_tools.append(kb_tool)
                     enhanced_prompt = self.agent_service._enhance_prompt_with_kb_info(
-                        enhanced_prompt, kb.name, kb.description, kb_binding.metadata_filters
+                        enhanced_prompt,
+                        kb.name,
+                        kb.description,
+                        kb_binding.metadata_filters,
                     )
 
         # データセット連携：ツールとプロンプト拡張を準備

--- a/src/services/agent_service.py
+++ b/src/services/agent_service.py
@@ -177,14 +177,15 @@ class PersonaAgent:
             thread = threading.Thread(target=_run_agent, daemon=True)
             thread.start()
 
-            while True:
-                token = token_queue.get()
-                if token is None:
-                    break
-                yield token
-
-            thread.join()
-            self.agent.callback_handler = original_handler
+            try:
+                while True:
+                    token = token_queue.get()
+                    if token is None:
+                        break
+                    yield token
+            finally:
+                thread.join()
+                self.agent.callback_handler = original_handler
 
             if agent_error:
                 raise agent_error
@@ -567,14 +568,15 @@ class FacilitatorAgent:
             thread = threading.Thread(target=_run_agent, daemon=True)
             thread.start()
 
-            while True:
-                token = token_queue.get()
-                if token is None:
-                    break
-                yield token
-
-            thread.join()
-            self.agent.callback_handler = original_handler
+            try:
+                while True:
+                    token = token_queue.get()
+                    if token is None:
+                        break
+                    yield token
+            finally:
+                thread.join()
+                self.agent.callback_handler = original_handler
 
             if agent_error:
                 raise agent_error

--- a/src/services/agent_service.py
+++ b/src/services/agent_service.py
@@ -3,9 +3,11 @@ Agent Service
 Strands Agent SDKを使用したエージェント管理サービス
 """
 
+import queue
 import random
 import logging
-from typing import List, Dict, Any, Optional
+import threading
+from typing import List, Dict, Any, Optional, Generator
 from dataclasses import asdict
 
 try:
@@ -118,6 +120,83 @@ class PersonaAgent:
             error_msg = (
                 f"ペルソナエージェント {self.persona.name} の応答生成に失敗: {e}"
             )
+            self.logger.error(error_msg)
+            raise AgentCommunicationError(error_msg)
+
+    def respond_streaming(
+        self,
+        prompt: str,
+        context: List[Message] | None = None,
+        include_documents: bool = True,
+    ) -> Generator[str, None, None]:
+        """
+        トークンを逐次yieldする応答生成
+
+        Args:
+            prompt: 発言を促すプロンプト
+            context: これまでの議論コンテキスト
+            include_documents: ドキュメントを含めるかどうか
+
+        Yields:
+            str: トークン文字列
+
+        Raises:
+            AgentCommunicationError: エージェント通信エラー
+        """
+        try:
+            full_prompt = self._build_prompt_with_context(prompt, context)
+            token_queue: queue.Queue[Optional[str]] = queue.Queue()
+
+            class _TokenCapture:
+                def __call__(self, **kwargs: Any) -> None:
+                    data = kwargs.get("data", "")
+                    if data:
+                        token_queue.put(data)
+
+            original_handler = self.agent.callback_handler
+            self.agent.callback_handler = _TokenCapture()
+
+            agent_error: Optional[Exception] = None
+
+            def _run_agent() -> None:
+                nonlocal agent_error
+                try:
+                    if include_documents and self._document_contents:
+                        content_blocks = [
+                            {"text": full_prompt}
+                        ] + self._document_contents
+                        self.agent(content_blocks)
+                        self._document_contents = []
+                    else:
+                        self.agent(full_prompt)
+                except Exception as e:
+                    agent_error = e
+                finally:
+                    token_queue.put(None)
+
+            thread = threading.Thread(target=_run_agent, daemon=True)
+            thread.start()
+
+            while True:
+                token = token_queue.get()
+                if token is None:
+                    break
+                yield token
+
+            thread.join()
+            self.agent.callback_handler = original_handler
+
+            if agent_error:
+                raise agent_error
+
+            self.logger.info(
+                f"ペルソナ {self.persona.name} がストリーミング応答を完了しました"
+            )
+
+        except AgentCommunicationError:
+            raise
+        except Exception as e:
+            error_msg = f"ペルソナエージェント {self.persona.name} のストリーミング応答生成に失敗: {e}"
             self.logger.error(error_msg)
             raise AgentCommunicationError(error_msg)
 
@@ -384,6 +463,130 @@ class FacilitatorAgent:
 
         except Exception as e:
             error_msg = f"ラウンド{round_number}の要約に失敗: {e}"
+            self.logger.error(error_msg)
+            raise AgentCommunicationError(error_msg)
+
+    def summarize_round_streaming(
+        self,
+        round_number: int,
+        round_messages: List[Message],
+        topic: str,
+        previous_summaries: List[str] | None = None,
+    ) -> Generator[str, None, None]:
+        """
+        ラウンドの議論を要約（トークンストリーミング版）
+
+        Args:
+            round_number: ラウンド番号
+            round_messages: そのラウンドのメッセージリスト
+            topic: 議論トピック
+            previous_summaries: 過去ラウンドの要約リスト
+
+        Yields:
+            str: トークン文字列
+
+        Raises:
+            AgentCommunicationError: エージェント通信エラー
+        """
+        try:
+            statements = [
+                msg
+                for msg in round_messages
+                if msg.message_type == "statement" and msg.persona_id != "facilitator"
+            ]
+
+            if not statements:
+                yield f"ラウンド{round_number}では発言がありませんでした。"
+                return
+
+            statements_text = "\n".join(
+                [f"- {msg.persona_name}: {msg.content}" for msg in statements]
+            )
+
+            parts = [
+                f"議論テーマ「{topic}」のラウンド{round_number}/{self.rounds}が完了しました。\n"
+            ]
+
+            if previous_summaries:
+                parts.append("## これまでの議論の流れ")
+                for i, summary in enumerate(previous_summaries, 1):
+                    parts.append(f"ラウンド{i}: {summary}")
+                parts.append("")
+
+            parts.append(f"## ラウンド{round_number}の発言")
+            parts.append(statements_text)
+            parts.append("")
+
+            if round_number < self.rounds:
+                parts.append(
+                    "以下の観点で簡潔に要約してください:\n"
+                    "- 各参加者の主要な意見や立場\n"
+                    "- 参加者間の共通点や対立点\n"
+                    "- まだ掘り下げられていない重要な観点\n"
+                    "- 各ペルソナに次のラウンドで答えてほしい具体的な問い（1-2個）\n"
+                    f"残り{self.rounds - round_number}ラウンドです。"
+                )
+                if self.rounds - round_number <= 2:
+                    parts.append(
+                        "論点を絞り込み、結論に向けて議論を収束させてください。"
+                    )
+                parts.append("3-5文で要約し、最後に問いかけで締めてください。")
+            else:
+                parts.append(
+                    "最終ラウンドが完了しました。以下の観点で議論全体をまとめてください:\n"
+                    "- 議論を通じて明らかになった主要な結論\n"
+                    "- 参加者間で合意に至った点と残った対立点\n"
+                    "- 議論テーマの目的に対する具体的な示唆\n"
+                    "5-7文で最終まとめを作成してください。"
+                )
+
+            prompt = "\n".join(parts)
+
+            token_queue: queue.Queue[Optional[str]] = queue.Queue()
+
+            class _TokenCapture:
+                def __call__(self, **kwargs: Any) -> None:
+                    data = kwargs.get("data", "")
+                    if data:
+                        token_queue.put(data)
+
+            original_handler = self.agent.callback_handler
+            self.agent.callback_handler = _TokenCapture()
+
+            agent_error: Optional[Exception] = None
+
+            def _run_agent() -> None:
+                nonlocal agent_error
+                try:
+                    self.agent(prompt)
+                except Exception as e:
+                    agent_error = e
+                finally:
+                    token_queue.put(None)
+
+            thread = threading.Thread(target=_run_agent, daemon=True)
+            thread.start()
+
+            while True:
+                token = token_queue.get()
+                if token is None:
+                    break
+                yield token
+
+            thread.join()
+            self.agent.callback_handler = original_handler
+
+            if agent_error:
+                raise agent_error
+
+            self.logger.info(
+                f"ラウンド{round_number}のストリーミング要約が完了しました"
+            )
+
+        except AgentCommunicationError:
+            raise
+        except Exception as e:
+            error_msg = f"ラウンド{round_number}のストリーミング要約に失敗: {e}"
             self.logger.error(error_msg)
             raise AgentCommunicationError(error_msg)
 

--- a/tests/unit/test_context_management.py
+++ b/tests/unit/test_context_management.py
@@ -13,7 +13,9 @@ from src.models.persona import Persona
 from src.services.agent_service import FacilitatorAgent, PersonaAgent
 
 
-def _create_test_persona(persona_id: str = "test-persona-1", name: str = "田中太郎") -> Persona:
+def _create_test_persona(
+    persona_id: str = "test-persona-1", name: str = "田中太郎"
+) -> Persona:
     return Persona(
         id=persona_id,
         name=name,
@@ -97,7 +99,10 @@ class TestFacilitatorPromptWithSummaries:
     def test_first_round_no_summaries(self):
         """ラウンド1: 具体的なエピソードを引き出す問いかけ"""
         self.facilitator.current_round = 1
-        persona_agent = Mock(get_persona_name=Mock(return_value="田中太郎"), get_persona_id=Mock(return_value="p1"))
+        persona_agent = Mock(
+            get_persona_name=Mock(return_value="田中太郎"),
+            get_persona_id=Mock(return_value="p1"),
+        )
         prompt = self.facilitator.create_prompt_for_persona(
             persona_agent, "新商品について", []
         )
@@ -144,11 +149,19 @@ class TestFacilitatorPromptWithSummaries:
         summaries = ["ラウンド1の要約"]
         recent = [
             Message.create_new("p1", "佐藤", "意見です", message_type="statement"),
-            Message.create_new("facilitator", "ファシリテータ", "論点整理: 次は価格について", message_type="summary"),
+            Message.create_new(
+                "facilitator",
+                "ファシリテータ",
+                "論点整理: 次は価格について",
+                message_type="summary",
+            ),
             Message.create_new("p2", "鈴木", "賛成です", message_type="statement"),
         ]
         prompt = self.facilitator.create_prompt_for_persona(
-            persona_agent, "テーマ", recent, round_summaries=summaries,
+            persona_agent,
+            "テーマ",
+            recent,
+            round_summaries=summaries,
             latest_facilitator_message="論点整理: 次は価格について",
         )
         # ファシリテータの問いかけが専用セクションに表示される
@@ -172,7 +185,10 @@ class TestFacilitatorPromptWithSummaries:
     def test_early_round_phase_instruction(self):
         """ラウンド1: 自分の体験を共有する指示"""
         self.facilitator.current_round = 1
-        persona_agent = Mock(get_persona_name=Mock(return_value="田中太郎"), get_persona_id=Mock(return_value="p1"))
+        persona_agent = Mock(
+            get_persona_name=Mock(return_value="田中太郎"),
+            get_persona_id=Mock(return_value="p1"),
+        )
         summaries = ["ラウンド1の要約"]
         recent = [Message.create_new("p2", "佐藤", "意見です")]
         prompt = self.facilitator.create_prompt_for_persona(
@@ -250,7 +266,9 @@ class TestSummarizeRoundImproved:
         """過去の要約が含まれること"""
         self.mock_agent.return_value = "ラウンド2の要約"
         messages = [
-            Message.create_new("p1", "田中", "具体的な価格帯は...", message_type="statement"),
+            Message.create_new(
+                "p1", "田中", "具体的な価格帯は...", message_type="statement"
+            ),
         ]
         prev = ["ラウンド1では価格vs品質が論点になった"]
         self.facilitator.summarize_round(2, messages, "新商品", previous_summaries=prev)
@@ -295,12 +313,18 @@ class TestAgentDiscussionContextManagement:
         mock_agent_1.get_persona_id.return_value = sample_persona.id
         mock_agent_1.get_persona_name.return_value = sample_persona.name
         mock_agent_1.respond.return_value = "テスト応答1"
+        mock_agent_1.respond_streaming.side_effect = lambda *a, **kw: iter(
+            ["テスト", "応答", "1"]
+        )
         mock_agent_1.clear_conversation_history = Mock()
 
         mock_agent_2 = Mock(spec=PersonaAgent)
         mock_agent_2.get_persona_id.return_value = sample_persona_2.id
         mock_agent_2.get_persona_name.return_value = sample_persona_2.name
         mock_agent_2.respond.return_value = "テスト応答2"
+        mock_agent_2.respond_streaming.side_effect = lambda *a, **kw: iter(
+            ["テスト", "応答", "2"]
+        )
         mock_agent_2.clear_conversation_history = Mock()
 
         persona_agents = [mock_agent_1, mock_agent_2]
@@ -316,6 +340,9 @@ class TestAgentDiscussionContextManagement:
             speaker_sequence.extend([mock_agent_1, mock_agent_2, None])
         mock_facilitator.select_next_speaker.side_effect = speaker_sequence
         mock_facilitator.summarize_round.return_value = "ラウンドの要約"
+        mock_facilitator.summarize_round_streaming.side_effect = lambda *a, **kw: iter(
+            ["ラウンド", "の", "要約"]
+        )
         mock_facilitator.increment_round.return_value = None
         mock_facilitator.current_round = 0
         mock_facilitator.rounds = rounds
@@ -325,6 +352,7 @@ class TestAgentDiscussionContextManagement:
         # increment_round で current_round を更新
         def _increment():
             mock_facilitator.current_round += 1
+
         mock_facilitator.increment_round.side_effect = _increment
 
         return manager, persona_agents, mock_facilitator
@@ -430,7 +458,7 @@ class TestAgentDiscussionContextManagement:
         facilitator.clear_conversation_history.assert_called_once()
 
         # 結果にメッセージとcompleteが含まれること
-        message_results = [r for r in results if r[0] == "message"]
+        message_end_results = [r for r in results if r[0] == "message_end"]
         complete_results = [r for r in results if r[0] == "complete"]
-        assert len(message_results) > 0
+        assert len(message_end_results) > 0
         assert len(complete_results) == 1

--- a/web/main.py
+++ b/web/main.py
@@ -40,7 +40,7 @@ async def lifespan(app: FastAPI) -> Any:
 app = FastAPI(
     title="AIペルソナシステム",
     description="AIペルソナを生成し、議論を通じてインサイトを生成",
-    version="0.10.2",
+    version="0.11.0",
     lifespan=lifespan,
 )
 
@@ -82,4 +82,4 @@ async def index(request: Request) -> Any:
 @app.get("/health")
 async def health_check() -> Any:
     """ヘルスチェック"""
-    return {"status": "healthy", "version": "0.10.2"}
+    return {"status": "healthy", "version": "0.11.0"}

--- a/web/routers/discussion.py
+++ b/web/routers/discussion.py
@@ -141,7 +141,8 @@ async def upload_discussion_document(file: UploadFile = File(...)) -> Any:
 
         # ファイルをアップロード
         file_metadata = file_manager.upload_discussion_document(
-            file_content=file_content, filename=file.filename  # type: ignore[arg-type]
+            file_content=file_content,
+            filename=file.filename,  # type: ignore[arg-type]
         )
 
         # JSONレスポンスを返す
@@ -160,7 +161,9 @@ async def upload_discussion_document(file: UploadFile = File(...)) -> Any:
         return JSONResponse({"error": e.user_message}, status_code=400)
     except Exception as e:
         logger.error(f"ドキュメントアップロードエラー: {e}")
-        return JSONResponse({"error": "ドキュメントのアップロードに失敗しました"}, status_code=400)
+        return JSONResponse(
+            {"error": "ドキュメントのアップロードに失敗しました"}, status_code=400
+        )
 
 
 @router.get("/result-partial/{discussion_id}", response_class=HTMLResponse)
@@ -246,7 +249,22 @@ def _stream_discussion_sync(
             enable_memory=enable_memory,
             document_ids=document_ids,
         ):
-            if event_type == "message":
+            if event_type == "message_start":
+                yield f"data: {json.dumps({'type': 'message_start', **data}, ensure_ascii=False)}\n\n"
+            elif event_type == "message_delta":
+                yield f"data: {json.dumps({'type': 'message_delta', **data}, ensure_ascii=False)}\n\n"
+            elif event_type == "message_end":
+                message_count += 1
+                msg_data = {
+                    "type": "message_end",
+                    "persona_id": data.persona_id,
+                    "persona_name": data.persona_name,
+                    "content": data.content,
+                    "message_type": data.message_type,
+                }
+                yield f"data: {json.dumps(msg_data, ensure_ascii=False)}\n\n"
+            elif event_type == "message":
+                # 後方互換: 非ストリーミングメッセージ
                 message_count += 1
                 msg_data = {
                     "type": "message",
@@ -556,7 +574,8 @@ async def discussion_results_page(
     # htmxリクエストの場合はパーシャルを返す
     if request.headers.get("HX-Request"):
         return templates.TemplateResponse(
-            "discussion/partials/discussion_list.html", ctx,
+            "discussion/partials/discussion_list.html",
+            ctx,
         )
 
     return templates.TemplateResponse(
@@ -962,8 +981,10 @@ async def generate_report_stream(
 ) -> Any:
     """レポートをSSEストリーミングで生成する"""
     if template_type not in ("summary", "review", "custom", "data_driven"):
+
         def error_gen() -> Any:
-            yield f'data: {json.dumps({"type": "error", "message": "無効なテンプレート種別です"}, ensure_ascii=False)}\n\n'
+            yield f"data: {json.dumps({'type': 'error', 'message': '無効なテンプレート種別です'}, ensure_ascii=False)}\n\n"
+
         return StreamingResponse(error_gen(), media_type="text/event-stream")
 
     def stream_generator() -> Any:
@@ -1031,13 +1052,18 @@ async def generate_report_stream(
                 template_type=template_type,
                 custom_prompt=custom_prompt or None,
             ):
-                data = json.dumps({"type": "chunk", "content": chunk}, ensure_ascii=False)
+                data = json.dumps(
+                    {"type": "chunk", "content": chunk}, ensure_ascii=False
+                )
                 yield f"data: {data}\n\n"
 
             yield f"data: {json.dumps({'type': 'done'}, ensure_ascii=False)}\n\n"
         except Exception as e:
             logger.error(f"レポート生成エラー: {e}")
-            data = json.dumps({"type": "error", "message": "レポートの生成に失敗しました"}, ensure_ascii=False)
+            data = json.dumps(
+                {"type": "error", "message": "レポートの生成に失敗しました"},
+                ensure_ascii=False,
+            )
             yield f"data: {data}\n\n"
 
     return StreamingResponse(
@@ -1073,6 +1099,7 @@ async def save_report(
 
         # 保存後、reportsセクション全体を再描画
         from src.config import Config
+
         discussion = discussion_manager.get_discussion(discussion_id)
         response = templates.TemplateResponse(
             "discussion/partials/reports.html",
@@ -1088,6 +1115,7 @@ async def save_report(
     except Exception as e:
         logger.error(f"レポート保存エラー: {e}")
         from src.models.discussion_report import DiscussionReport as DR
+
         report = DR(
             id=report_id,
             template_type=template_type,
@@ -1153,6 +1181,7 @@ async def export_report(
         if format == "txt":
             # Markdown記法を除去
             import re
+
             content = re.sub(r"#{1,6}\s*", "", content)
             content = re.sub(r"\*{1,2}(.*?)\*{1,2}", r"\1", content)
             content = re.sub(r"_{1,2}(.*?)_{1,2}", r"\1", content)
@@ -1161,6 +1190,7 @@ async def export_report(
         filename = f"report_{report.template_type}_{timestamp}.{format}"
 
         from fastapi.responses import Response
+
         return Response(
             content=content,
             media_type="text/plain; charset=utf-8",
@@ -1188,6 +1218,7 @@ async def delete_report(
     except Exception as e:
         logger.error(f"レポート削除エラー: {e}")
         from markupsafe import escape
+
         return HTMLResponse(
             content=f"<div class='text-red-600'>{escape(str(e))}</div>",
             status_code=400,

--- a/web/routers/interview.py
+++ b/web/routers/interview.py
@@ -94,7 +94,14 @@ def _prepare_file_content_block(
 
     elif mime_type == "application/pdf":
         # PDFの場合
-        safe_name = re.sub(r"[^a-zA-Z0-9_]", "_", filename.rsplit(".", 1)[0])[:100]
+        safe_name = (
+            re.sub(
+                r"\s+",
+                " ",
+                re.sub(r"[^a-zA-Z0-9\s\-\(\)\[\]]", " ", filename.rsplit(".", 1)[0]),
+            ).strip()[:100]
+            or "document"
+        )
         return {
             "document": {
                 "name": safe_name,
@@ -112,7 +119,14 @@ def _prepare_file_content_block(
             "text/markdown": "md",
         }
         doc_format = format_map.get(mime_type, "txt")
-        safe_name = re.sub(r"[^a-zA-Z0-9_]", "_", filename.rsplit(".", 1)[0])[:100]
+        safe_name = (
+            re.sub(
+                r"\s+",
+                " ",
+                re.sub(r"[^a-zA-Z0-9\s\-\(\)\[\]]", " ", filename.rsplit(".", 1)[0]),
+            ).strip()[:100]
+            or "document"
+        )
         return {
             "document": {
                 "name": safe_name,
@@ -241,7 +255,11 @@ async def create_interview_session(
     except InterviewValidationError as e:
         logger.error(f"Interview validation error: {e}")
         return JSONResponse(
-            {"error": "入力内容に問題があります。内容を確認してください。", "error_type": "validation_error"}, status_code=400
+            {
+                "error": "入力内容に問題があります。内容を確認してください。",
+                "error_type": "validation_error",
+            },
+            status_code=400,
         )
     except InterviewAgentError as e:
         logger.error(f"Interview agent error: {e}")
@@ -329,6 +347,141 @@ async def interview_chat_page(request: Request, session_id: str) -> Any:
                 "error": "ページの読み込み中にエラーが発生しました。しばらく待ってから再試行してください。",
             },
             status_code=500,
+        )
+
+
+@router.post("/{session_id}/message/stream")
+async def send_message_stream(
+    request: Request,
+    session_id: str,
+    message: str = Form(...),
+    files: Optional[List[UploadFile]] = File(None),
+) -> Any:
+    """メッセージ送信ストリーミングエンドポイント（トークン単位SSE）"""
+    try:
+        if not message or not message.strip():
+            return StreamingResponse(
+                iter(
+                    [
+                        f"data: {json.dumps({'type': 'error', 'message': 'メッセージが空です'}, ensure_ascii=False)}\n\n"
+                    ]
+                ),
+                media_type="text/event-stream",
+            )
+
+        # ドキュメント処理
+        document_contents: list[Dict[str, Any]] = []
+        document_metadata: list[Dict[str, Any]] = []
+        if files:
+            for file in files:
+                if file.filename and file.size and file.size > 0:
+                    content_type = file.content_type or ""
+                    if content_type in SUPPORTED_IMAGE_TYPES + SUPPORTED_DOCUMENT_TYPES:
+                        file_bytes = await file.read()
+                        if content_type in SUPPORTED_IMAGE_TYPES:
+                            img_format = content_type.split("/")[-1]
+                            if img_format == "jpeg":
+                                img_format = "jpeg"
+                            document_contents.append(
+                                {
+                                    "image": {
+                                        "format": img_format,
+                                        "source": {"bytes": file_bytes},
+                                    }
+                                }
+                            )
+                        else:
+                            raw_name = (file.filename or "doc").rsplit(".", 1)[0]
+                            doc_name = re.sub(
+                                r"[^a-zA-Z0-9\s\-\(\)\[\]]", " ", raw_name
+                            )
+                            doc_name = (
+                                re.sub(r"\s+", " ", doc_name).strip() or "document"
+                            )
+                            doc_format = "pdf" if "pdf" in content_type else "txt"
+                            document_contents.append(
+                                {
+                                    "document": {
+                                        "name": doc_name[:200],
+                                        "format": doc_format,
+                                        "source": {"bytes": file_bytes},
+                                    }
+                                }
+                            )
+                        document_metadata.append(
+                            {
+                                "filename": file.filename,
+                                "mime_type": content_type,
+                                "file_size": file.size,
+                                "uploaded_at": datetime.now().isoformat(),
+                            }
+                        )
+
+        interview_manager = get_interview_manager()
+
+        queue: asyncio.Queue[Any] = asyncio.Queue()
+
+        def run_streaming() -> None:
+            try:
+                for event_type, data in interview_manager.send_user_message_streaming(
+                    session_id,
+                    message.strip(),
+                    document_contents=document_contents or None,
+                    document_metadata=document_metadata or None,
+                ):
+                    if event_type == "message_start":
+                        sse = f"data: {json.dumps({'type': 'message_start', **data}, ensure_ascii=False)}\n\n"
+                    elif event_type == "message_delta":
+                        sse = f"data: {json.dumps({'type': 'message_delta', **data}, ensure_ascii=False)}\n\n"
+                    elif event_type == "message_end":
+                        sse = f"data: {json.dumps({'type': 'message_end', 'persona_id': data.persona_id, 'persona_name': data.persona_name, 'content': data.content, 'message_type': data.message_type}, ensure_ascii=False)}\n\n"
+                    else:
+                        continue
+                    asyncio.run_coroutine_threadsafe(queue.put(sse), loop)
+                # Complete signal
+                complete_sse = (
+                    f"data: {json.dumps({'type': 'complete'}, ensure_ascii=False)}\n\n"
+                )
+                asyncio.run_coroutine_threadsafe(queue.put(complete_sse), loop)
+            except Exception as e:
+                logger.error(f"Interview streaming error: {e}")
+                error_sse = f"data: {json.dumps({'type': 'error', 'message': str(e)}, ensure_ascii=False)}\n\n"
+                asyncio.run_coroutine_threadsafe(queue.put(error_sse), loop)
+            finally:
+                asyncio.run_coroutine_threadsafe(queue.put(None), loop)
+
+        loop = asyncio.get_event_loop()
+
+        async def event_generator() -> Any:
+            executor.submit(run_streaming)
+            while True:
+                try:
+                    event = await asyncio.wait_for(queue.get(), timeout=30)
+                    if event is None:
+                        break
+                    yield event
+                except asyncio.TimeoutError:
+                    yield f"data: {json.dumps({'type': 'keepalive'}, ensure_ascii=False)}\n\n"
+
+        return StreamingResponse(
+            event_generator(),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "Connection": "keep-alive",
+                "X-Accel-Buffering": "no",
+            },
+        )
+
+    except Exception as e:
+        logger.error(f"Interview stream endpoint error: {e}")
+        return StreamingResponse(
+            iter(
+                [
+                    f"data: {json.dumps({'type': 'error', 'message': 'ストリーミング開始中にエラーが発生しました'}, ensure_ascii=False)}\n\n"
+                ]
+            ),
+            media_type="text/event-stream",
         )
 
 
@@ -497,7 +650,11 @@ async def send_message(
     except InterviewValidationError as e:
         logger.error(f"Validation error: {e}")
         return JSONResponse(
-            {"error": "入力内容に問題があります。内容を確認してください。", "error_type": "validation_error"}, status_code=400
+            {
+                "error": "入力内容に問題があります。内容を確認してください。",
+                "error_type": "validation_error",
+            },
+            status_code=400,
         )
     except InterviewAgentError as e:
         logger.error(f"Agent error: {e}")
@@ -554,7 +711,9 @@ async def get_messages(request: Request, session_id: str) -> Any:
 
     except InterviewManagerError as e:
         logger.error(f"Error getting messages: {e}")
-        return JSONResponse({"error": "メッセージ履歴が見つかりません"}, status_code=404)
+        return JSONResponse(
+            {"error": "メッセージ履歴が見つかりません"}, status_code=404
+        )
     except Exception as e:
         logger.error(f"Unexpected error getting messages: {e}")
         return JSONResponse(
@@ -725,7 +884,11 @@ async def save_interview_session(
     except InterviewValidationError as e:
         logger.error(f"Validation error during save: {e}")
         return JSONResponse(
-            {"error": "保存内容に問題があります。内容を確認してください。", "error_type": "validation_error"}, status_code=400
+            {
+                "error": "保存内容に問題があります。内容を確認してください。",
+                "error_type": "validation_error",
+            },
+            status_code=400,
         )
     except InterviewPersistenceError as e:
         logger.error(f"Persistence error during save: {e}")
@@ -770,7 +933,9 @@ async def end_interview_session(request: Request, session_id: str) -> Any:
 
     except InterviewManagerError as e:
         logger.error(f"Error ending interview session: {e}")
-        return JSONResponse({"error": "インタビューセッションの終了に失敗しました"}, status_code=400)
+        return JSONResponse(
+            {"error": "インタビューセッションの終了に失敗しました"}, status_code=400
+        )
     except Exception as e:
         logger.error(f"Unexpected error ending interview session: {e}")
         return JSONResponse(

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -157,7 +157,7 @@
     <footer class="bg-white border-t mt-auto">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
             <p class="text-center text-gray-500 text-sm">
-                AIペルソナシステム v0.10.2
+                AIペルソナシステム v0.11.0
             </p>
         </div>
     </footer>

--- a/web/templates/discussion/setup.html
+++ b/web/templates/discussion/setup.html
@@ -221,30 +221,97 @@
                   const eventSource = new EventSource(url);
                   let discussionComplete = false;
                   
+                  let currentStreamingEl = null;
+                  let currentAccumulatedText = '';
+
+                  function createBubble(info) {
+                      const isFacilitator = info.persona_id === 'facilitator' || info.message_type === 'summary';
+                      const safeName = escapeHtml(info.persona_name || '');
+                      let msgHtml;
+                      if (isFacilitator) {
+                          msgHtml = `
+                              <div class='flex justify-center my-4 message-item fade-in'>
+                                  <div class='facilitator-bubble max-w-2xl'>
+                                      <div class='flex items-center gap-2 mb-2'>
+                                          <div class='w-8 h-8 rounded-full facilitator-avatar flex items-center justify-center'>
+                                              <svg class='w-4 h-4 text-white' fill='none' stroke='currentColor' viewBox='0 0 24 24'><path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M9 3v2m6-2v2M9 19v2m6-2v2M5 9H3m2 6H3m18-6h-2m2 6h-2M7 19h10a2 2 0 002-2V7a2 2 0 00-2-2H7a2 2 0 00-2 2v10a2 2 0 002 2zM9 9h6v6H9V9z'></path></svg>
+                                          </div>
+                                          <span class='font-bold'>ファシリテーター</span>
+                                      </div>
+                                      <div class='leading-relaxed prose prose-sm max-w-none streaming-content'></div>
+                                  </div>
+                              </div>
+                          `;
+                      } else {
+                          const pInfo = participantMap[info.persona_id] || { name: info.persona_name, colorIndex: 0 };
+                          const color = personaColors[pInfo.colorIndex % personaColors.length];
+                          msgHtml = `
+                              <div class='flex gap-3 message-item fade-in'>
+                                  <div class='flex-shrink-0'>
+                                      <div class='w-12 h-12 rounded-full persona-avatar-${color} flex items-center justify-center shadow-md'>
+                                          <span class='text-white font-bold text-lg'>${safeName[0] || ''}</span>
+                                      </div>
+                                  </div>
+                                  <div class='flex-1 min-w-0'>
+                                      <div class='flex items-baseline gap-2 mb-1'>
+                                          <span class='font-bold persona-name-${color} text-lg'>${safeName}</span>
+                                      </div>
+                                      <div class='persona-bubble-${color} border rounded-2xl rounded-tl-none p-4 shadow-sm'>
+                                          <div class='text-gray-800 leading-relaxed prose prose-sm max-w-none streaming-content'></div>
+                                      </div>
+                                  </div>
+                              </div>
+                          `;
+                      }
+                      const tempDiv = document.createElement('div');
+                      tempDiv.innerHTML = DOMPurify.sanitize(msgHtml); // nosemgrep: insecure-document-method
+                      const bubble = tempDiv.firstElementChild;
+                      container.appendChild(bubble);
+                      return bubble.querySelector('.streaming-content');
+                  }
+
                   eventSource.onmessage = function(event) {
                       const data = JSON.parse(event.data);
-                      
+
                       if (data.type === 'keepalive') {
-                          // keep-alive: 何もしない（接続維持のみ）
                           return;
                       } else if (data.type === 'participants') {
                           data.personas.forEach((p, idx) => {
                               participantMap[p.id] = { name: p.name, colorIndex: idx };
                           });
-                      } else if (data.type === 'message') {
+                      } else if (data.type === 'message_start') {
+                          currentAccumulatedText = '';
+                          currentStreamingEl = createBubble(data);
+                          container.scrollTop = container.scrollHeight;
+                      } else if (data.type === 'message_delta') {
+                          currentAccumulatedText += data.content;
+                          if (currentStreamingEl) {
+                              currentStreamingEl.innerHTML = DOMPurify.sanitize(
+                                  marked.parse(currentAccumulatedText, {breaks: true})
+                              );
+                              container.scrollTop = container.scrollHeight;
+                          }
+                      } else if (data.type === 'message_end') {
                           messageCount++;
                           counter.textContent = messageCount + ' 発言';
-                          
-                          // ファシリテーターの発言かどうかを判定
+                          if (currentStreamingEl) {
+                              currentStreamingEl.innerHTML = DOMPurify.sanitize(
+                                  marked.parse(data.content, {breaks: true})
+                              );
+                          }
+                          currentStreamingEl = null;
+                          currentAccumulatedText = '';
+                      } else if (data.type === 'message') {
+                          // 後方互換: Traditional mode 等の完成メッセージ
+                          messageCount++;
+                          counter.textContent = messageCount + ' 発言';
+
                           const isFacilitator = data.persona_id === 'facilitator' || data.message_type === 'summary';
-                          
-                          // サーバーサイドでサニタイズ済みHTMLを使用（フォールバックはテキストをエスケープ）
-                          const renderedContent = data.content_html || escapeHtml(data.content).replace(/\n/g, '<br>');
+                          const renderedContent = data.content_html || DOMPurify.sanitize(marked.parse(data.content, {breaks: true}));
                           const safeName = escapeHtml(data.persona_name || '');
-                          
+
                           let msgHtml;
                           if (isFacilitator) {
-                              // ファシリテーターの発言（中央寄せ、グレー背景）
                               msgHtml = `
                                   <div class='flex justify-center my-4 message-item fade-in'>
                                       <div class='facilitator-bubble max-w-2xl'>
@@ -259,10 +326,8 @@
                                   </div>
                               `;
                           } else {
-                              // ペルソナの発言
                               const info = participantMap[data.persona_id] || { name: data.persona_name, colorIndex: 0 };
                               const color = personaColors[info.colorIndex % personaColors.length];
-                              
                               msgHtml = `
                                   <div class='flex gap-3 message-item fade-in'>
                                       <div class='flex-shrink-0'>
@@ -285,7 +350,7 @@
                           tempDiv.innerHTML = DOMPurify.sanitize(msgHtml); // nosemgrep: insecure-document-method
                           while (tempDiv.firstChild) container.appendChild(tempDiv.firstChild);
                           container.scrollTop = container.scrollHeight;
-                          
+
                       } else if (data.type === 'complete') {
                           discussionComplete = true;
                           eventSource.close();

--- a/web/templates/discussion/setup.html
+++ b/web/templates/discussion/setup.html
@@ -280,6 +280,9 @@
                               participantMap[p.id] = { name: p.name, colorIndex: idx };
                           });
                       } else if (data.type === 'message_start') {
+                          if (currentStreamingEl && !currentAccumulatedText) {
+                              currentStreamingEl.textContent = '[応答を取得できませんでした]';
+                          }
                           currentAccumulatedText = '';
                           currentStreamingEl = createBubble(data);
                           container.scrollTop = container.scrollHeight;

--- a/web/templates/interview/chat.html
+++ b/web/templates/interview/chat.html
@@ -564,6 +564,9 @@ async function sendMessage(message) {
                 if (data.type === 'keepalive') {
                     continue;
                 } else if (data.type === 'message_start') {
+                    if (currentStreamingEl && !currentAccumulatedText) {
+                        currentStreamingEl.textContent = '[応答を取得できませんでした]';
+                    }
                     receivedResponse = true;
                     currentAccumulatedText = '';
                     currentStreamingEl = createStreamingBubble(data.persona_name, data.persona_id);

--- a/web/templates/interview/chat.html
+++ b/web/templates/interview/chat.html
@@ -485,71 +485,119 @@ function formatFileSize(bytes) {
 // メッセージ送信処理
 async function sendMessage(message) {
     const sessionId = '{{ session.id }}';
-    
+
     // メッセージもファイルもない場合は送信しない
     if (!message && selectedFiles.length === 0) {
         return;
     }
-    
+
     try {
-        
         // UI状態を送信中に変更
         setSendingState(true);
-        
+
         // ユーザーメッセージを即座に表示（添付ファイル情報も含む）
         addUserMessage(message, selectedFiles);
         messageInput.value = '';
         messageInput.style.height = 'auto';
         if (charCounter) charCounter.textContent = '0/500';
-        
+
         // ローディング表示
         showLoadingIndicator();
-        
-        // HTTPリクエストを送信
+
+        // HTTPリクエストを送信（ストリーミング版）
         const formData = new FormData();
         formData.append('message', message || '（添付ファイルを確認してください）');
-        
+
         // 選択されたファイルを追加
         for (const file of selectedFiles) {
             formData.append('files', file);
         }
-        
-        const requestUrl = `/interview/${sessionId}/message`;
-        
-        const response = await fetch(requestUrl, {
-            method: 'POST',
-            body: formData,
-            headers: {'X-Requested-With': 'XMLHttpRequest'}
-        });
-        
-        if (!response.ok) {
-            throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-        }
-        
-        const data = await response.json();
-        
+
         // 送信成功後、選択ファイルをクリア
         selectedFiles = [];
         updateFilePreview();
-        
-        if (data.error) {
-            showDetailedError(data.error, data.error_type, data.technical_details);
-        } else if (data.responses && data.responses.length > 0) {
-            // ペルソナの応答を順次表示
-            for (let i = 0; i < data.responses.length; i++) {
-                const response = data.responses[i];
-                setTimeout(() => {
-                    addPersonaMessage(response.persona_name, response.content, response.timestamp, response.persona_id, response.content_html);
-                }, i * 800); // 800ms間隔で表示
+
+        const requestUrl = `/interview/${sessionId}/message/stream`;
+
+        const response = await fetch(requestUrl, {
+            method: 'POST',
+            body: formData,
+            headers: {'X-Requested-With': 'XMLHttpRequest'},
+        });
+
+        if (!response.ok) {
+            throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+        }
+
+        // SSEストリームをReadableStreamで読み取る
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
+        let currentStreamingEl = null;
+        let currentAccumulatedText = '';
+        let receivedResponse = false;
+
+        hideLoadingIndicator();
+
+        while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+
+            buffer += decoder.decode(value, { stream: true });
+
+            // SSEイベントをパース
+            const lines = buffer.split('\n');
+            buffer = lines.pop() || '';
+
+            for (const line of lines) {
+                if (!line.startsWith('data: ')) continue;
+                const jsonStr = line.slice(6);
+                if (!jsonStr) continue;
+
+                let data;
+                try {
+                    data = JSON.parse(jsonStr);
+                } catch (e) {
+                    continue;
+                }
+
+                if (data.type === 'keepalive') {
+                    continue;
+                } else if (data.type === 'message_start') {
+                    receivedResponse = true;
+                    currentAccumulatedText = '';
+                    currentStreamingEl = createStreamingBubble(data.persona_name, data.persona_id);
+                } else if (data.type === 'message_delta') {
+                    currentAccumulatedText += data.content;
+                    if (currentStreamingEl) {
+                        currentStreamingEl.innerHTML = DOMPurify.sanitize(
+                            marked.parse(currentAccumulatedText, {breaks: true})
+                        );
+                        scrollToBottom();
+                    }
+                } else if (data.type === 'message_end') {
+                    if (currentStreamingEl) {
+                        currentStreamingEl.innerHTML = DOMPurify.sanitize(
+                            marked.parse(data.content, {breaks: true})
+                        );
+                    }
+                    currentStreamingEl = null;
+                    currentAccumulatedText = '';
+                } else if (data.type === 'complete') {
+                    // ストリーミング完了
+                } else if (data.type === 'error') {
+                    showDetailedError(data.message, 'agent_error');
+                }
             }
-        } else {
+        }
+
+        if (!receivedResponse) {
             showDetailedError('ペルソナからの応答がありませんでした', 'no_response');
         }
-        
+
     } catch (error) {
         console.error('Send message error:', error);
-        
-        // ネットワークエラーかどうかを判定
+
         if (error.name === 'TypeError' && error.message.includes('fetch')) {
             showDetailedError(
                 'ネットワーク接続に問題があります。インターネット接続を確認してください。',
@@ -566,7 +614,6 @@ async function sendMessage(message) {
                 'agent_error'
             );
         } else if (error.message.includes('保存済み')) {
-            // 保存済みセッションでのメッセージ送信エラー
             disableMessageSending('このセッションは既に保存されています。新しいメッセージは送信できません。');
             showDetailedError(
                 'このセッションは既に保存されているため、新しいメッセージを送信できません。',
@@ -580,12 +627,42 @@ async function sendMessage(message) {
             );
         }
     } finally {
-        // ローディング状態をリセット
         setTimeout(() => {
             hideLoadingIndicator();
             setSendingState(false);
-        }, 1000);
+        }, 300);
     }
+}
+
+function createStreamingBubble(personaName, personaId) {
+    if (!chatMessages) return null;
+    const colorClass = getPersonaColor(personaId);
+    const timeStr = new Date().toLocaleTimeString('ja-JP', {hour: '2-digit', minute: '2-digit'});
+
+    const messageDiv = document.createElement('div');
+    messageDiv.className = 'message-item persona-message animate-fade-in';
+    safeSetInnerHTML(messageDiv, `
+        <div class="flex gap-3 mb-4">
+            <div class="flex-shrink-0">
+                <div class="w-12 h-12 rounded-full ${colorClass} flex items-center justify-center shadow-md ring-2 ring-white">
+                    <span class="text-white font-bold text-sm">${escapeHtml(personaName)[0]}</span>
+                </div>
+            </div>
+            <div class="flex-1 min-w-0">
+                <div class="flex items-baseline gap-2 mb-2">
+                    <span class="font-semibold text-gray-900 text-sm">${escapeHtml(personaName)}</span>
+                    <span class="text-xs text-gray-500 bg-gray-100 px-2 py-1 rounded-full">ペルソナ</span>
+                    <span class="text-xs text-gray-400">${timeStr}</span>
+                </div>
+                <div class="bg-gray-50 border border-gray-200 rounded-2xl rounded-tl-md px-4 py-3 shadow-sm">
+                    <div class="text-gray-800 text-sm leading-relaxed prose prose-sm max-w-none streaming-content"></div>
+                </div>
+            </div>
+        </div>
+    `);
+    chatMessages.appendChild(messageDiv);
+    scrollToBottom();
+    return messageDiv.querySelector('.streaming-content');
 }
 
 // UI状態管理関数


### PR DESCRIPTION
## Summary

- Agent mode（しっかり議論）とインタビューモードのペルソナ発言をトークン単位でリアルタイム表示
- SSEプロトコルを `message_start` / `message_delta` / `message_end` の3フェーズに拡張
- ファシリテータの要約発言もストリーミング対応
- フロントエンドで `marked.js` + `DOMPurify` によるプログレッシブMarkdownレンダリング
- Bedrock ConverseStream APIのドキュメント名バリデーション修正

## 変更内容

| レイヤー | 変更 |
|---------|------|
| Service | `PersonaAgent.respond_streaming()`, `FacilitatorAgent.summarize_round_streaming()` 追加（callback_handler + Queue + Thread） |
| Manager | `start_agent_discussion_streaming()` を3フェーズyieldに変更、`InterviewManager.send_user_message_streaming()` 追加 |
| Router | Agent mode SSEに新イベントタイプ追加、`POST /interview/{id}/message/stream` 追加 |
| Frontend | `setup.html`, `chat.html` でストリーミングバブル作成 + progressive render |

## Test plan

- [x] `uv run ruff check .` — All checks passed
- [x] `uv run mypy src/ web/` — Success: no issues found
- [x] `uv run pytest tests/unit/ -q` — 715 passed
- [x] ブラウザでAgent modeしっかり議論を実行し、トークン単位で表示されることを確認
- [x] ブラウザでインタビューモードを実行し、トークン単位で表示されることを確認
- [x] Traditional mode（簡易議論）が従来通り動作することを確認（後方互換）
- [x] ドキュメント添付付きインタビューが正常動作することを確認