### PR TITLE
fix: Lambda@EdgeランタイムをNode.js 22.xへ更新（Node 20 EOL対応）

### DIFF
--- a/cdk/lib/constructs/cloudfront.ts
+++ b/cdk/lib/constructs/cloudfront.ts
@@ -80,7 +80,7 @@ exports.handler = async (event) => {
 
     const authFunction = new cloudfront.experimental.EdgeFunction(this, 'AuthAtEdge', {
       functionName: `ai-persona-auth-edge-${envName}`,
-      runtime: lambda.Runtime.NODEJS_20_X,
+      runtime: lambda.Runtime.NODEJS_22_X,
       handler: 'index.handler',
       code: lambda.Code.fromAsset(lambdaDir),
       memorySize: 128,


### PR DESCRIPTION
## 背景

CloudFront の Lambda@Edge（Cognito認証）のランタイムが `NODEJS_20_X` で固定されており、Node.js 20.x の end-of-life 通知が届いていた。

## 変更内容

`cdk/lib/constructs/cloudfront.ts` のランタイム指定を `NODEJS_20_X` → `NODEJS_22_X` に変更（1行）。

```diff
- runtime: lambda.Runtime.NODEJS_20_X,
+ runtime: lambda.Runtime.NODEJS_22_X,
```

## 調査結果

- 認証ライブラリ `cognito-at-edge` は最新版 `1.5.4`（npm `latest`・インストール済み）で `engines` は `node: >=10.0.0`。Node 22 を含むため**ライブラリのバージョンアップは不要**。
- aws-cdk-lib 2.252.0 は `NODEJS_22_X` をサポート済み。Lambda@Edge も Node.js 22 ランタイムに対応。
- `cdk/lambda/auth-at-edge/index.js` は標準的な `async/await` と `require` のみで Node 22 互換性問題なし。

## 検証

- `npx tsc --noEmit` 通過
- `npx cdk synth` 成功、合成テンプレートで `"Runtime": "nodejs22.x"` を確認
- pre-push-review: PASS

## 留意点

- デプロイ時、Lambda@Edge は us-east-1 に新バージョンが発行され、CloudFront 更新の伝播（数分）が走る。デプロイ前に `npx cdk diff` で差分確認を推奨。
- 同関数ディレクトリ配下の推移的依存（form-data）のセキュリティパッチは別 PR #90 で対応。

Closes #91