### PR TITLE
fix: 生成ペルソナキャッシュTTL改善 (#100)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,6 @@ BATCH_INFERENCE_MODEL_ID=global.anthropic.claude-haiku-4-5-20251001-v1:0
 BEDROCK_BATCH_ROLE_ARN=arn:aws:iam::123456789012:role/BedrockBatchInferenceRole
 SURVEY_S3_PREFIX=survey-results/
 BATCH_INFERENCE_S3_PREFIX=batch-inference/
+
+# ペルソナ生成キャッシュTTL（秒、デフォルト: 14400 = 4時間）
+# PERSONA_CACHE_TTL_SECONDS=14400

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-persona-system"
-version = "0.16.5"
+version = "0.16.6"
 description = "AIペルソナシステム - インタビューからペルソナを生成し、議論を通じてインサイトを生成"
 authors = [
     {name = "AI Persona Team"}

--- a/src/config.py
+++ b/src/config.py
@@ -63,6 +63,9 @@ class Config:
     DATA_AGENT_REGION: str = "ap-northeast-1"
     ENABLE_DATA_AGENT: bool = False
 
+    # ペルソナ生成キャッシュ設定
+    PERSONA_CACHE_TTL_SECONDS: int = 14400  # 4 hours
+
     def __post_init__(self) -> None:
         """設定の初期化後処理"""
         # 環境変数から設定を上書き
@@ -118,6 +121,11 @@ class Config:
             self.ENABLE_DATA_AGENT = True
         elif enable_val in ("false", "0", "no"):
             self.ENABLE_DATA_AGENT = False
+
+        # ペルソナ生成キャッシュ設定を環境変数から上書き
+        persona_cache_ttl = os.getenv("PERSONA_CACHE_TTL_SECONDS")
+        if persona_cache_ttl:
+            self.PERSONA_CACHE_TTL_SECONDS = int(persona_cache_ttl)
 
         # ディレクトリの存在確認と作成
         self._ensure_directories()

--- a/src/managers/interview_manager.py
+++ b/src/managers/interview_manager.py
@@ -521,8 +521,11 @@ class InterviewManager:
         # Enhanced validation with specific error messages
         try:
             self._validate_session_for_save(session)
+        except InterviewValidationError:
+            raise
         except Exception as e:
-            raise InterviewValidationError(f"セッション保存の検証に失敗しました: {e}")
+            self.logger.error(f"セッション保存の検証エラー: {e}")
+            raise InterviewValidationError("セッション保存の検証に失敗しました")
 
         # Check if already saved
         if session.is_saved:

--- a/src/managers/persona_generation_manager.py
+++ b/src/managers/persona_generation_manager.py
@@ -11,6 +11,7 @@ from cachetools import TTLCache  # type: ignore[import-untyped]
 from pydantic import BaseModel, Field
 
 from ..models.persona import Persona
+from ..config import config
 from ..services.agent_service import AgentService, AgentServiceError
 from ..services.database_service import DatabaseService
 from ..services.service_factory import service_factory
@@ -80,8 +81,12 @@ class PersonaGenerationManager:
         self.database_service = (
             database_service or service_factory.get_database_service()
         )
-        self._personas_cache: TTLCache = TTLCache(maxsize=1000, ttl=1800)
-        self._behavior_datasets_cache: TTLCache = TTLCache(maxsize=100, ttl=1800)
+        self._personas_cache: TTLCache = TTLCache(
+            maxsize=1000, ttl=config.PERSONA_CACHE_TTL_SECONDS
+        )
+        self._behavior_datasets_cache: TTLCache = TTLCache(
+            maxsize=100, ttl=config.PERSONA_CACHE_TTL_SECONDS
+        )
 
     # ------------------------------------------------------------------
     # 公開API
@@ -374,7 +379,6 @@ class PersonaGenerationManager:
         self, data_type: str, use_mcp: bool, event_queue: Any
     ) -> list[Any]:
         """生成に使用するツールリストを決定する"""
-        from ..config import config
 
         tools: list[Any] = []
 

--- a/src/managers/settings_manager.py
+++ b/src/managers/settings_manager.py
@@ -114,6 +114,7 @@ class SettingsManager:
         except SettingsManagerError:
             raise
         except Exception as e:
+            logger.error(f"データ分析エージェント接続テストエラー: {e}")
             raise SettingsManagerError(
-                f"データ分析エージェント接続テストに失敗しました: {e}"
+                "データ分析エージェント接続テストに失敗しました"
             ) from e

--- a/tests/api/test_persona_router.py
+++ b/tests/api/test_persona_router.py
@@ -500,7 +500,7 @@ class TestSaveSelectedPersonasEndpoint:
     def test_save_selected_not_found_in_cache(
         self, mock_get_manager, mock_get_gen_manager, client
     ):
-        """キャッシュにないペルソナでエラーを返すことを確認"""
+        """キャッシュ期限切れで専用エラーメッセージを返すことを確認"""
         mock_gen_manager = Mock()
         mock_gen_manager.get_cached_persona.return_value = None
         mock_gen_manager.pop_cached_persona.return_value = None
@@ -514,7 +514,28 @@ class TestSaveSelectedPersonasEndpoint:
         )
 
         assert response.status_code == 500
-        assert "保存に失敗しました" in response.text
+        assert "一時データが期限切れ" in response.text
+
+    @patch("web.routers.persona.get_persona_generation_manager")
+    @patch("web.routers.persona.get_persona_manager")
+    def test_save_selected_partial_cache_miss(
+        self, mock_get_manager, mock_get_gen_manager, client, sample_persona
+    ):
+        """一部キャッシュ切れでも保存成功分はカウントされることを確認"""
+        mock_gen_manager = Mock()
+        mock_gen_manager.get_cached_persona.side_effect = [sample_persona, None]
+        mock_gen_manager.pop_cached_persona.return_value = None
+        mock_get_gen_manager.return_value = mock_gen_manager
+
+        mock_manager = Mock()
+        mock_get_manager.return_value = mock_manager
+
+        response = client.post(
+            "/persona/save-selected", data={"persona_ids": "id1,id2"}
+        )
+
+        assert response.status_code == 200
+        mock_manager.save_persona.assert_called_once_with(sample_persona)
 
 
 class TestPersonaEditForm:

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 
 [[package]]
 name = "ai-persona-system"
-version = "0.16.5"
+version = "0.16.6"
 source = { editable = "." }
 dependencies = [
     { name = "bedrock-agentcore" },

--- a/web/routers/persona.py
+++ b/web/routers/persona.py
@@ -1345,6 +1345,7 @@ async def save_selected_personas(request: Request, persona_ids: str = Form(...))
 
         persona_manager = get_persona_manager()
         saved_count = 0
+        cache_miss_count = 0
 
         # 各ペルソナを保存
         gen_manager = get_persona_generation_manager()
@@ -1357,6 +1358,7 @@ async def save_selected_personas(request: Request, persona_ids: str = Form(...))
                     saved_count += 1
                     logger.info(f"ペルソナ保存成功: {persona.name} (ID: {persona_id})")
                 else:
+                    cache_miss_count += 1
                     logger.warning(f"ペルソナが見つかりません (ID: {persona_id})")
             except Exception as e:
                 logger.error(f"ペルソナ保存エラー (ID: {persona_id}): {e}")
@@ -1368,10 +1370,14 @@ async def save_selected_personas(request: Request, persona_ids: str = Form(...))
             gen_manager.pop_cached_persona(persona_id)
 
         if saved_count == 0:
+            if cache_miss_count == len(id_list):
+                error_msg = "生成されたペルソナの一時データが期限切れです。お手数ですが再度生成してください。"
+            else:
+                error_msg = "ペルソナの保存に失敗しました"
             return templates.TemplateResponse(
                 request,
                 "partials/error.html",
-                {"request": request, "error": "ペルソナの保存に失敗しました"},
+                {"request": request, "error": error_msg},
                 status_code=500,
             )
 


### PR DESCRIPTION
## Summary

- 生成ペルソナのTTLキャッシュを30分→4時間に延長（環境変数`PERSONA_CACHE_TTL_SECONDS`で変更可能）
- キャッシュ期限切れ時のサイレントエラーを解消し、ユーザーに再生成を促す専用メッセージを表示
- CodeQL alert #41 対応: `settings_manager`/`interview_manager`の内部例外情報をHTTPレスポンスから除去

## Test plan

- [x] `uv run pytest tests/api/test_persona_router.py -q -k save_selected` — 期限切れメッセージ・部分保存テストがパス
- [x] `uv run ruff check .` — All checks passed
- [x] `uv run mypy src/ web/` — No issues found
- [x] `uv run pytest -m unit -q` — 982 passed
- [x] `/pre-push-review` — PASS
- [x] `/security-review` — No vulnerabilities found

Closes #100