### PR TITLE
fix: エラーレスポンスから例外メッセージの直接露出を除去

### DIFF
--- a/tests/api/test_interview_router.py
+++ b/tests/api/test_interview_router.py
@@ -206,7 +206,7 @@ class TestSendMessageEndpoint:
 
         assert response.status_code == 400
         data = response.json()
-        assert "長すぎます" in data["error"]
+        assert data["error"] == "入力内容に問題があります"
 
     @patch("web.routers.interview.get_interview_manager")
     def test_send_message_session_not_found(self, mock_get_manager, client):

--- a/web/routers/interview.py
+++ b/web/routers/interview.py
@@ -443,7 +443,7 @@ async def send_message(
         logger.error(f"Validation error: {e}")
         return JSONResponse(
             {
-                "error": str(e),
+                "error": "入力内容に問題があります",
                 "error_type": "validation_error",
             },
             status_code=400,

--- a/web/routers/settings.py
+++ b/web/routers/settings.py
@@ -454,10 +454,9 @@ async def test_data_agent_connection(request: Request) -> Any:
             "}"
             "</script>"
         )
-    except SettingsManagerError as e:
-        escaped = html.escape(str(e))
+    except SettingsManagerError:
         return HTMLResponse(
-            f'<div class="text-sm text-red-600 bg-red-50 rounded p-2">{escaped}</div>'
+            '<div class="text-sm text-red-600 bg-red-50 rounded p-2">接続失敗: データ分析エージェントに接続できませんでした</div>'
         )
     except Exception:
         logger.exception("データ分析エージェント接続テストエラー")


### PR DESCRIPTION
## Summary
- `web/routers/interview.py`: `InterviewValidationError`の`str(e)`をレスポンスに含めていた箇所を固定メッセージに置換
- `web/routers/settings.py`: `SettingsManagerError`の`str(e)`をレスポンスに含めていた箇所を固定メッセージに置換
- CodeQL「Information exposure through an exception」アラートを解消

## Test plan
- [x] インタビューチャットで空メッセージ送信時、内部例外メッセージがレスポンスに含まれないことを確認
- [x] 設定画面のデータ分析エージェント接続テスト失敗時、固定メッセージが表示されることを確認
- [x] `uv run pytest tests/api/ -q` パス確認