### PR TITLE
fix: リージョンがus-east-1以外の場合のLambda@Edge/WAFデプロイ失敗を修正

### DIFF
--- a/cdk/README.md
+++ b/cdk/README.md
@@ -229,6 +229,14 @@ cognitoDomainPrefix: 'ai-persona-dev-abc123xyz',
 npx cdk bootstrap aws://<ACCOUNT_ID>/<AWS_REGION>
 ```
 
+**重要: `<AWS_REGION>` が us-east-1 以外の場合**
+
+Lambda@Edge（`cloudfront.experimental.EdgeFunction`）と WAF WebACL は us-east-1 に作成されます。特に Lambda@Edge のサポートスタックは Lambda コードをアセットとして含むため、デプロイ先リージョンが us-east-1 以外の場合は us-east-1 も bootstrap しないとメインスタックのデプロイが失敗します。
+
+```bash
+npx cdk bootstrap aws://<ACCOUNT_ID>/us-east-1
+```
+
 ### 4. ECR Stackのデプロイ
 
 ```bash

--- a/cdk/README.md
+++ b/cdk/README.md
@@ -182,8 +182,11 @@ chmod +x destroy.sh
 ./destroy.sh --region <AWS_REGION>
 ```
 
-スタックの依存関係に基づき、正しい順序（Cognito → Main → Memory → ECR）で自動削除されます。
+スタックの依存関係に基づき、正しい順序（MCP → Cognito → Main → WAF → Memory → ECR）で自動削除されます。
+MCP Gateway（`--enable-mcp` でデプロイした場合）はメインスタックの export を参照しているため、メインスタックより先に削除されます。
 dev環境ではS3バケットの中身は `autoDeleteObjects` により自動削除されます。
+
+デプロイ先リージョンが us-east-1 以外の場合、Lambda@Edge の関数は us-east-1 に自動生成されるサポートスタック（`edge-lambda-stack-*`）に配置されます。`destroy.sh` はこれを検出し、メインスタック削除後に us-east-1 で削除します。ただし CloudFront のレプリカ削除には数時間かかるため、初回は削除に失敗することがあります。その場合は時間を置いて再度 `./destroy.sh` を実行してください。
 
 #### オプション
 
@@ -394,9 +397,19 @@ CLOUDFRONT_DOMAIN=$(aws cloudformation describe-stacks \
   --query "Stacks[0].Outputs[?OutputKey=='CloudFrontDomainName'].OutputValue" \
   --output text)
 
+# Cognito User Pool ID / Client ID も CognitoStack の出力から取得できる
+USER_POOL_ID=$(aws cloudformation describe-stacks \
+  --stack-name AIPersonaCognito-dev --region <AWS_REGION> \
+  --query "Stacks[0].Outputs[?OutputKey=='UserPoolId'].OutputValue" \
+  --output text)
+CLIENT_ID=$(aws cloudformation describe-stacks \
+  --stack-name AIPersonaCognito-dev --region <AWS_REGION> \
+  --query "Stacks[0].Outputs[?OutputKey=='UserPoolClientId'].OutputValue" \
+  --output text)
+
 aws cognito-idp update-user-pool-client \
-  --user-pool-id <USER_POOL_ID> \
-  --client-id <CLIENT_ID> \
+  --user-pool-id "${USER_POOL_ID}" \
+  --client-id "${CLIENT_ID}" \
   --region <AWS_REGION> \
   --callback-urls "https://${CLOUDFRONT_DOMAIN}" "https://${CLOUDFRONT_DOMAIN}/" \
   --logout-urls "https://${CLOUDFRONT_DOMAIN}" "https://${CLOUDFRONT_DOMAIN}/" \
@@ -413,26 +426,40 @@ aws cognito-idp update-user-pool-client \
 ```bash
 cd cdk
 
-# 1. Cognito Stack
+# 1. MCP Gateway Stack（--enable-mcp でデプロイした場合のみ。メインスタックの
+#    export を import しているため、メインスタックより先に削除する）
+npx cdk destroy AIPersonaMcp-dev
+
+# 2. Cognito Stack
 npx cdk destroy AIPersonaCognito-dev
 
-# 2. Main Stack（S3バケットを先に空にする）
+# 3. Main Stack（S3バケットを先に空にする）
 aws s3 rm s3://<BUCKET_NAME> --recursive
 npx cdk destroy AIPersona-dev
 
-# 3. WAF Stack（使用している場合、us-east-1にデプロイされている）
+# 4. WAF Stack（使用している場合、us-east-1にデプロイされている）
 npx cdk destroy AIPersonaWaf-dev
 
-# 4. Memory Stack
+# 5. Memory Stack
 npx cdk destroy AIPersonaMemory-dev
 
-# 5. ECR Stack（イメージを先に削除）
+# 6. ECR Stack（イメージを先に削除）
 aws ecr batch-delete-image --repository-name ai-persona-dev \
   --image-ids "$(aws ecr list-images --repository-name ai-persona-dev --query 'imageIds[*]' --output json)"
 npx cdk destroy AIPersonaEcr-dev
+
+# 7. Lambda@Edge サポートスタック（デプロイ先が us-east-1 以外の場合のみ）
+#    us-east-1 に edge-lambda-stack-<hash> という名前で自動生成されている。
+#    レプリカ削除の遅延で数時間は削除に失敗するため、時間を置いてから実行する。
+aws cloudformation list-stacks --region us-east-1 \
+  --stack-status-filter CREATE_COMPLETE UPDATE_COMPLETE DELETE_FAILED \
+  --query "StackSummaries[?starts_with(StackName, 'edge-lambda-stack')].StackName" --output text
+aws cloudformation delete-stack --stack-name <EDGE_STACK_NAME> --region us-east-1
 ```
 
 > **注意**: S3バケットやECRリポジトリに中身が残っていると削除に失敗します。必ず事前にクリーンアップしてください。
+>
+> **注意**: `--enable-mcp` でデプロイした環境で MCP Gateway スタックを残したままメインスタックを削除しようとすると、export 参照エラーで失敗します。必ず MCP Gateway スタックを先に削除してください。
 
 ## 出力値
 
@@ -482,12 +509,26 @@ CloudFront Lambda@Edge + [cognito-at-edge](https://github.com/awslabs/cognito-at
 ### callbackUrlの手動更新（必要な場合）
 
 ```bash
+# User Pool ID / Client ID / CloudFront ドメインは各スタックの出力から取得できる
+USER_POOL_ID=$(aws cloudformation describe-stacks \
+  --stack-name AIPersonaCognito-dev --region <REGION> \
+  --query "Stacks[0].Outputs[?OutputKey=='UserPoolId'].OutputValue" \
+  --output text)
+CLIENT_ID=$(aws cloudformation describe-stacks \
+  --stack-name AIPersonaCognito-dev --region <REGION> \
+  --query "Stacks[0].Outputs[?OutputKey=='UserPoolClientId'].OutputValue" \
+  --output text)
+CLOUDFRONT_DOMAIN=$(aws cloudformation describe-stacks \
+  --stack-name AIPersona-dev --region <REGION> \
+  --query "Stacks[0].Outputs[?OutputKey=='CloudFrontDomainName'].OutputValue" \
+  --output text)
+
 aws cognito-idp update-user-pool-client \
-  --user-pool-id <USER_POOL_ID> \
-  --client-id <CLIENT_ID> \
+  --user-pool-id "${USER_POOL_ID}" \
+  --client-id "${CLIENT_ID}" \
   --region <REGION> \
-  --callback-urls "https://<CLOUDFRONT_DOMAIN>" "https://<CLOUDFRONT_DOMAIN>/" \
-  --logout-urls "https://<CLOUDFRONT_DOMAIN>" "https://<CLOUDFRONT_DOMAIN>/" \
+  --callback-urls "https://${CLOUDFRONT_DOMAIN}" "https://${CLOUDFRONT_DOMAIN}/" \
+  --logout-urls "https://${CLOUDFRONT_DOMAIN}" "https://${CLOUDFRONT_DOMAIN}/" \
   --allowed-o-auth-flows code \
   --allowed-o-auth-scopes openid email profile \
   --allowed-o-auth-flows-user-pool-client \

--- a/deploy.sh
+++ b/deploy.sh
@@ -208,6 +208,16 @@ npx cdk bootstrap "aws://${ACCOUNT_ID}/${REGION}" --region "${REGION}" 2>&1 || {
   log_warn "Bootstrap済みの可能性があります。続行します。"
 }
 
+# Lambda@Edge（cloudfront.experimental.EdgeFunction）とWAF WebACLはus-east-1に作成される。
+# EdgeFunctionのサポートスタックはLambdaコードをアセットとして含むため、
+# ${REGION}がus-east-1以外の場合はus-east-1もbootstrapしないとメインスタックのデプロイが失敗する。
+if [[ "${REGION}" != "us-east-1" ]]; then
+  log_info "Lambda@Edge/WAF用にus-east-1もbootstrapします"
+  npx cdk bootstrap "aws://${ACCOUNT_ID}/us-east-1" --region "us-east-1" 2>&1 || {
+    log_warn "us-east-1はBootstrap済みの可能性があります。続行します。"
+  }
+fi
+
 # ===== ECR Stack デプロイ =====
 log_step "Step 4: ECRリポジトリの作成"
 

--- a/destroy.sh
+++ b/destroy.sh
@@ -64,11 +64,15 @@ fi
 PROJECT_ROOT="${SCRIPT_DIR}"
 
 # スタック名定義
+MCP_STACK="AIPersonaMcp-${ENV_NAME}"
 COGNITO_STACK="AIPersonaCognito-${ENV_NAME}"
 MAIN_STACK="AIPersona-${ENV_NAME}"
 WAF_STACK="AIPersonaWaf-${ENV_NAME}"
 MEMORY_STACK="AIPersonaMemory-${ENV_NAME}"
 ECR_STACK="AIPersonaEcr-${ENV_NAME}"
+# Lambda@Edge サポートスタック（REGIONがus-east-1以外の場合にus-east-1へ自動生成される。
+# 名前は edge-lambda-stack-<hash> と動的なため、検出時に特定する）
+EDGE_STACK=""
 
 # ===== 削除対象の確認 =====
 log_step "削除対象スタックの確認"
@@ -77,8 +81,27 @@ stack_exists() {
   aws cloudformation describe-stacks --stack-name "$1" --region "${REGION}" > /dev/null 2>&1
 }
 
+# us-east-1 の edge-lambda-stack-* から本プロジェクト（この環境名）のLambda@Edge
+# サポートスタックを特定する。関数名 ai-persona-auth-edge-${ENV_NAME} を含むものを探す。
+find_edge_stack() {
+  local candidates s
+  candidates=$(aws cloudformation list-stacks --region us-east-1 \
+    --stack-status-filter CREATE_COMPLETE UPDATE_COMPLETE UPDATE_ROLLBACK_COMPLETE IMPORT_COMPLETE DELETE_FAILED \
+    --query "StackSummaries[?starts_with(StackName, 'edge-lambda-stack')].StackName" \
+    --output text 2>/dev/null || echo "")
+  for s in ${candidates}; do
+    if aws cloudformation describe-stack-resources --stack-name "${s}" --region us-east-1 \
+        --query "StackResources[?ResourceType=='AWS::Lambda::Function'].PhysicalResourceId" \
+        --output text 2>/dev/null | grep -q "ai-persona-auth-edge-${ENV_NAME}"; then
+      echo "${s}"
+      return 0
+    fi
+  done
+  echo ""
+}
+
 STACKS_TO_DELETE=()
-for stack in "${COGNITO_STACK}" "${MAIN_STACK}" "${MEMORY_STACK}" "${ECR_STACK}"; do
+for stack in "${MCP_STACK}" "${COGNITO_STACK}" "${MAIN_STACK}" "${MEMORY_STACK}" "${ECR_STACK}"; do
   if stack_exists "${stack}"; then
     log_info "  存在: ${stack}"
     STACKS_TO_DELETE+=("${stack}")
@@ -92,6 +115,16 @@ if aws cloudformation describe-stacks --stack-name "${WAF_STACK}" --region us-ea
   STACKS_TO_DELETE+=("${WAF_STACK}")
 else
   log_info "  なし: ${WAF_STACK} (スキップ)"
+fi
+# Lambda@Edge サポートスタック（REGIONがus-east-1以外の場合のみ、us-east-1を検索）
+if [[ "${REGION}" != "us-east-1" ]]; then
+  EDGE_STACK=$(find_edge_stack)
+  if [[ -n "${EDGE_STACK}" ]]; then
+    log_info "  存在: ${EDGE_STACK} (us-east-1 / Lambda@Edge)"
+    STACKS_TO_DELETE+=("${EDGE_STACK}")
+  else
+    log_info "  なし: Lambda@Edge サポートスタック (us-east-1) (スキップ)"
+  fi
 fi
 
 if [[ ${#STACKS_TO_DELETE[@]} -eq 0 ]]; then
@@ -137,17 +170,25 @@ delete_stack() {
 
 # ===== 削除実行（依存関係の逆順） =====
 
-# 1. Cognito Stack
-if stack_exists "${COGNITO_STACK}"; then
-  log_step "Step 1: Cognito Stackの削除"
-  delete_stack "${COGNITO_STACK}" "${REGION}"
+# 1. MCP Gateway Stack（メインスタックの export を import しているため最初に削除）
+if stack_exists "${MCP_STACK}"; then
+  log_step "Step 1: MCP Gateway Stackの削除"
+  delete_stack "${MCP_STACK}" "${REGION}"
 else
-  log_info "Step 1: ${COGNITO_STACK} はスキップ"
+  log_info "Step 1: ${MCP_STACK} はスキップ"
 fi
 
-# 2. Main Stack
+# 2. Cognito Stack
+if stack_exists "${COGNITO_STACK}"; then
+  log_step "Step 2: Cognito Stackの削除"
+  delete_stack "${COGNITO_STACK}" "${REGION}"
+else
+  log_info "Step 2: ${COGNITO_STACK} はスキップ"
+fi
+
+# 3. Main Stack
 if stack_exists "${MAIN_STACK}"; then
-  log_step "Step 2: メインスタックの削除"
+  log_step "Step 3: メインスタックの削除"
 
   if [[ "${ENV_NAME}" == "prod" ]]; then
     log_warn "prod環境のため、S3バケットとDynamoDBテーブルはスタック削除後も残ります"
@@ -156,28 +197,28 @@ if stack_exists "${MAIN_STACK}"; then
 
   delete_stack "${MAIN_STACK}" "${REGION}"
 else
-  log_info "Step 2: ${MAIN_STACK} はスキップ"
+  log_info "Step 3: ${MAIN_STACK} はスキップ"
 fi
 
-# 3. WAF Stack (us-east-1)
+# 4. WAF Stack (us-east-1)
 if aws cloudformation describe-stacks --stack-name "${WAF_STACK}" --region us-east-1 > /dev/null 2>&1; then
-  log_step "Step 3: WAF Stackの削除 (us-east-1)"
+  log_step "Step 4: WAF Stackの削除 (us-east-1)"
   delete_stack "${WAF_STACK}" "us-east-1"
 else
-  log_info "Step 3: ${WAF_STACK} はスキップ"
+  log_info "Step 4: ${WAF_STACK} はスキップ"
 fi
 
-# 4. Memory Stack
+# 5. Memory Stack
 if stack_exists "${MEMORY_STACK}"; then
-  log_step "Step 4: AgentCore Memory Stackの削除"
+  log_step "Step 5: AgentCore Memory Stackの削除"
   delete_stack "${MEMORY_STACK}" "${REGION}"
 else
-  log_info "Step 4: ${MEMORY_STACK} はスキップ"
+  log_info "Step 5: ${MEMORY_STACK} はスキップ"
 fi
 
-# 5. ECR Stack
+# 6. ECR Stack
 if stack_exists "${ECR_STACK}"; then
-  log_step "Step 5: ECR Stackの削除"
+  log_step "Step 6: ECR Stackの削除"
 
   ECR_REPO=$(aws cloudformation describe-stack-resources \
     --stack-name "${ECR_STACK}" --region "${REGION}" \
@@ -195,7 +236,21 @@ if stack_exists "${ECR_STACK}"; then
 
   delete_stack "${ECR_STACK}" "${REGION}"
 else
-  log_info "Step 5: ${ECR_STACK} はスキップ"
+  log_info "Step 6: ${ECR_STACK} はスキップ"
+fi
+
+# 7. Lambda@Edge サポートスタック (us-east-1)
+# メインスタック（CloudFront）削除後に削除する。レプリカ削除の遅延で初回は失敗し得るため
+# ベストエフォート（失敗してもスクリプト全体は止めない）。
+if [[ -n "${EDGE_STACK}" ]]; then
+  if aws cloudformation describe-stacks --stack-name "${EDGE_STACK}" --region us-east-1 > /dev/null 2>&1; then
+    log_step "Step 7: Lambda@Edge サポートスタックの削除 (us-east-1)"
+    delete_stack "${EDGE_STACK}" "us-east-1" || {
+      log_warn "Lambda@Edge サポートスタック(${EDGE_STACK})は数時間後に再度 ./destroy.sh を実行して削除してください"
+    }
+  else
+    log_info "Step 7: ${EDGE_STACK} はスキップ"
+  fi
 fi
 
 # ===== 完了 =====

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-persona-system"
-version = "0.18.1"
+version = "0.18.2"
 description = "AIペルソナシステム - インタビューからペルソナを生成し、議論を通じてインサイトを生成"
 authors = [
     {name = "AI Persona Team"}

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 
 [[package]]
 name = "ai-persona-system"
-version = "0.18.1"
+version = "0.18.2"
 source = { editable = "." }
 dependencies = [
     { name = "bedrock-agentcore" },


### PR DESCRIPTION
## 概要

デプロイ先リージョンが us-east-1 以外で、かつ us-east-1 が一度も `cdk bootstrap` されていない場合、メインスタックのデプロイが Lambda@Edge のサポートスタック作成時に失敗する問題を修正。

## 背景

- `cdk/lib/constructs/cloudfront.ts` は `cloudfront.experimental.EdgeFunction`（Lambda@Edge）を使用。この construct は親スタックが us-east-1 以外の場合、Lambda を格納するサポートスタックを **us-east-1 に自動生成**し、メインスタックの依存として追加する。
- そのサポートスタックは Lambda コードを **アセットとして含む**ため、デプロイには us-east-1 の bootstrap（ステージングバケット等）が必須。
- WAF WebACL も us-east-1 に作成される（`bin/app.ts`）。
- しかし `deploy.sh` は `${REGION}` しか bootstrap しておらず、`--region ap-northeast-1` などを指定すると `This stack uses assets, so the toolkit stack must be deployed ... (Run "cdk bootstrap aws://<account>/us-east-1")` で失敗する。

## 変更内容

- `deploy.sh`: `${REGION}` が us-east-1 以外のとき、us-east-1 も無条件で `cdk bootstrap` するブロックを追加（bootstrap 済みでも `|| log_warn` で継続）
- `cdk/README.md`: 手動デプロイ手順にも同じ us-east-1 bootstrap の注意書きを追加
- バージョン bump: 0.18.1 → 0.18.2

## 確認

- `bash -n deploy.sh` 構文チェック済み
- Python / CDK(TS) コードは未変更のため機械チェック（ruff/mypy/pytest/cdk diff）は非該当