### PR TITLE
fix: WAF有効環境でファイルアップロードが403になる問題を修正（#132）

### DIFF
--- a/cdk/README.md
+++ b/cdk/README.md
@@ -378,6 +378,8 @@ WAFスタックはCloudFront用のためus-east-1にデプロイされます：
 npx cdk deploy AIPersonaWaf-dev
 ```
 
+> **注意**: CommonRuleSet の `SizeRestrictions_BODY`（ボディ8KB制限）はファイルアップロードと両立しないため、`lib/waf-stack.ts` でCountに落としています。
+
 ### 9. Main Stackのデプロイ
 
 ```bash

--- a/cdk/lib/waf-stack.ts
+++ b/cdk/lib/waf-stack.ts
@@ -53,7 +53,13 @@ export class WafStack extends Stack {
           priority: 1,
           overrideAction: { none: {} },
           statement: {
-            managedRuleGroupStatement: { vendorName: 'AWS', name: 'AWSManagedRulesCommonRuleSet' },
+            managedRuleGroupStatement: {
+              vendorName: 'AWS',
+              name: 'AWSManagedRulesCommonRuleSet',
+              // SizeRestrictions_BODY（ボディ8KB制限）はファイルアップロード（10MB/ファイル）と
+              // 両立しないためCountに落とす。サイズ検証はアプリ側で実施
+              ruleActionOverrides: [{ name: 'SizeRestrictions_BODY', actionToUse: { count: {} } }],
+            },
           },
           visibilityConfig: { cloudWatchMetricsEnabled: true, metricName: 'AWSManagedRulesCommonRuleSet', sampledRequestsEnabled: true },
         },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-persona-system"
-version = "0.18.2"
+version = "0.18.3"
 description = "AIペルソナシステム - インタビューからペルソナを生成し、議論を通じてインサイトを生成"
 authors = [
     {name = "AI Persona Team"}

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 
 [[package]]
 name = "ai-persona-system"
-version = "0.18.2"
+version = "0.18.3"
 source = { editable = "." }
 dependencies = [
     { name = "bedrock-agentcore" },


### PR DESCRIPTION
## 変更概要(#132)

WAF を有効化した環境でファイルアップロードが CloudFront から 403「Request blocked」を返す問題を修正します。

- `AWSManagedRulesCommonRuleSet` の `SizeRestrictions_BODY`（リクエストボディを8KBに制限）が multipart のファイルアップロードをブロックしていた。`ruleActionOverrides` で当該ルールのみ `Count` に落とし、ルールグループ内の他ルールの保護は維持する
- サイズ検証はアプリ側に存在するため WAF 側の 8KB 制限は不要（`src/managers/file_manager.py` で拡張子・サイズ（10MB/ファイル）・空ファイルを検証、合計文字数は `PersonaGenerationManager`）
- `cdk/README.md` の手順8に注意書きを1行追加
- バージョンを 0.18.3 に更新

影響範囲はペルソナ生成に限らず、`UploadFile` を受ける全エンドポイント（知識ファイル・議論ドキュメント・アンケート画像など）です。アップロードは presigned URL 直送ではなく全て CloudFront 経由の multipart POST のため、同じ条件で失敗していました。

## 発生条件

`enableWaf: true` かつ `allowedIpAddresses` が空の構成でのみ発生します。IP 許可リストがある場合は priority 0 の Allow が評価を終端し、CommonRuleSet もレートリミットも評価されないため再現しません（WAF は Allow を終端アクションとして扱う）。

## 検証

| 項目 | 結果 |
|---|---|
| `npx tsc --noEmit` | PASS |
| `npx cdk synth --no-staging` | PASS |
| `npx cdk synth AIPersonaWaf-prod -c env=prod` | `RuleActionOverrides: SizeRestrictions_BODY → Count` を確認 |
| `uv run ruff check .` | All checks passed |
| `uv run mypy src/ web/` | no issues (82 files) |
| `uv run pytest tests/unit/test_architecture_deps.py` | 72 passed |
| `uv run pytest -m unit --cov=src/managers` | 1190 passed / coverage 82% |

## レビュー時に留意いただきたい点

- **デプロイ後の実アップロード確認が未実施です。** `SizeRestrictions_BODY` で終端していたリクエストが後続のボディ検査ルール（`CrossSiteScripting_BODY` 等）まで到達するようになるため、別ルールでのブロックが顕在化する可能性が残ります。マージ後にステージングで確認が必要です
- `npx cdk diff` は影響環境とは別アカウントで実行したため権威ある差分になっていません。静的には `AWS::WAFv2::WebACL` のプロパティ更新のみで、ステートフルリソースの置換は発生しません
- `cdk/` にテスト設定がないため、オーバーライドの存在を検証する `Template.fromStack` アサーションは入れていません

## 今後の検討事項（本PRの範囲外）

IP 許可リストを設定した構成では CommonRuleSet とレートリミットが一度も評価されていません。IP 制限を「許可IPを Allow + 既定 Block」から「非許可IPを Block + 既定 Allow」へ反転させると3つすべてが有効になりますが、`defaultAction` がフェイルオープン側に変わるため CDK アサーションテストの追加とレートリミット閾値の見直しが前提になります。別途 Issue 化して判断します。

関連: #132
