### PR TITLE
fix: deploy.shのsed -iをmacOS(BSD sed)対応にする

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -49,6 +49,16 @@ log_warn()  { echo -e "${YELLOW}[WARN]${NC} $1"; }
 log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 log_step()  { echo -e "\n${BLUE}========================================${NC}"; echo -e "${BLUE}  $1${NC}"; echo -e "${BLUE}========================================${NC}"; }
 
+# sedのインプレース編集（GNU sed / BSD sed 両対応）
+# macOSのBSD sedでは -i にバックアップ拡張子の引数が必須なため、OSによって呼び分ける
+sed_inplace() {
+  if [[ "$(uname)" == "Darwin" ]]; then
+    sed -i '' "$@"
+  else
+    sed -i "$@"
+  fi
+}
+
 # ===== 引数パース =====
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -289,9 +299,9 @@ if [[ "${SKIP_MEMORY}" == "false" ]]; then
     log_info "Summary Strategy ID: ${SUMMARY_STRATEGY_ID}"
     log_info "Semantic Strategy ID: ${SEMANTIC_STRATEGY_ID}"
 
-    sed -i "s/agentCoreMemoryId: ''/agentCoreMemoryId: '${MEMORY_ID}'/" "${PROJECT_ROOT}/cdk/parameters.ts"
-    sed -i "s/summaryMemoryStrategyId: ''/summaryMemoryStrategyId: '${SUMMARY_STRATEGY_ID}'/" "${PROJECT_ROOT}/cdk/parameters.ts"
-    sed -i "s/semanticMemoryStrategyId: ''/semanticMemoryStrategyId: '${SEMANTIC_STRATEGY_ID}'/" "${PROJECT_ROOT}/cdk/parameters.ts"
+    sed_inplace "s/agentCoreMemoryId: ''/agentCoreMemoryId: '${MEMORY_ID}'/" "${PROJECT_ROOT}/cdk/parameters.ts"
+    sed_inplace "s/summaryMemoryStrategyId: ''/summaryMemoryStrategyId: '${SUMMARY_STRATEGY_ID}'/" "${PROJECT_ROOT}/cdk/parameters.ts"
+    sed_inplace "s/semanticMemoryStrategyId: ''/semanticMemoryStrategyId: '${SEMANTIC_STRATEGY_ID}'/" "${PROJECT_ROOT}/cdk/parameters.ts"
     log_info "parameters.ts を更新しました"
   fi
 else
@@ -315,9 +325,9 @@ else
         --query 'memory.strategies[?type==`SEMANTIC`].strategyId' \
         --output text 2>/dev/null || echo "")
 
-      sed -i "s/agentCoreMemoryId: ''/agentCoreMemoryId: '${MEMORY_ID}'/" "${PROJECT_ROOT}/cdk/parameters.ts"
-      sed -i "s/summaryMemoryStrategyId: ''/summaryMemoryStrategyId: '${SUMMARY_STRATEGY_ID}'/" "${PROJECT_ROOT}/cdk/parameters.ts"
-      sed -i "s/semanticMemoryStrategyId: ''/semanticMemoryStrategyId: '${SEMANTIC_STRATEGY_ID}'/" "${PROJECT_ROOT}/cdk/parameters.ts"
+      sed_inplace "s/agentCoreMemoryId: ''/agentCoreMemoryId: '${MEMORY_ID}'/" "${PROJECT_ROOT}/cdk/parameters.ts"
+      sed_inplace "s/summaryMemoryStrategyId: ''/summaryMemoryStrategyId: '${SUMMARY_STRATEGY_ID}'/" "${PROJECT_ROOT}/cdk/parameters.ts"
+      sed_inplace "s/semanticMemoryStrategyId: ''/semanticMemoryStrategyId: '${SEMANTIC_STRATEGY_ID}'/" "${PROJECT_ROOT}/cdk/parameters.ts"
       log_info "既存のMemory設定をparameters.tsに反映しました"
     fi
   fi
@@ -350,9 +360,9 @@ if [[ "${SKIP_COGNITO}" == "false" ]]; then
   log_info "Cognito Client ID: ${COGNITO_CLIENT_ID}"
   log_info "Cognito Domain: ${COGNITO_DOMAIN}"
 
-  sed -i "s/cognitoUserPoolId: ''/cognitoUserPoolId: '${COGNITO_USER_POOL_ID}'/" "${PROJECT_ROOT}/cdk/parameters.ts"
-  sed -i "s/cognitoUserPoolAppId: ''/cognitoUserPoolAppId: '${COGNITO_CLIENT_ID}'/" "${PROJECT_ROOT}/cdk/parameters.ts"
-  sed -i "s/cognitoUserPoolDomain: ''/cognitoUserPoolDomain: '${COGNITO_DOMAIN}'/" "${PROJECT_ROOT}/cdk/parameters.ts"
+  sed_inplace "s/cognitoUserPoolId: ''/cognitoUserPoolId: '${COGNITO_USER_POOL_ID}'/" "${PROJECT_ROOT}/cdk/parameters.ts"
+  sed_inplace "s/cognitoUserPoolAppId: ''/cognitoUserPoolAppId: '${COGNITO_CLIENT_ID}'/" "${PROJECT_ROOT}/cdk/parameters.ts"
+  sed_inplace "s/cognitoUserPoolDomain: ''/cognitoUserPoolDomain: '${COGNITO_DOMAIN}'/" "${PROJECT_ROOT}/cdk/parameters.ts"
   log_info "parameters.ts にCognito設定を反映しました"
 else
   log_info "Cognito認証をスキップします"
@@ -376,9 +386,9 @@ else
       --query "Stacks[0].Outputs[?OutputKey=='UserPoolDomainName'].OutputValue" \
       --output text)
 
-    sed -i "s/cognitoUserPoolId: ''/cognitoUserPoolId: '${COGNITO_USER_POOL_ID}'/" "${PROJECT_ROOT}/cdk/parameters.ts"
-    sed -i "s/cognitoUserPoolAppId: ''/cognitoUserPoolAppId: '${COGNITO_CLIENT_ID}'/" "${PROJECT_ROOT}/cdk/parameters.ts"
-    sed -i "s/cognitoUserPoolDomain: ''/cognitoUserPoolDomain: '${COGNITO_DOMAIN}'/" "${PROJECT_ROOT}/cdk/parameters.ts"
+    sed_inplace "s/cognitoUserPoolId: ''/cognitoUserPoolId: '${COGNITO_USER_POOL_ID}'/" "${PROJECT_ROOT}/cdk/parameters.ts"
+    sed_inplace "s/cognitoUserPoolAppId: ''/cognitoUserPoolAppId: '${COGNITO_CLIENT_ID}'/" "${PROJECT_ROOT}/cdk/parameters.ts"
+    sed_inplace "s/cognitoUserPoolDomain: ''/cognitoUserPoolDomain: '${COGNITO_DOMAIN}'/" "${PROJECT_ROOT}/cdk/parameters.ts"
     log_info "既存のCognito設定をparameters.tsに反映しました"
   fi
 fi
@@ -394,7 +404,7 @@ if [[ -z "${DATA_AGENT_ARN}" ]]; then
   if [[ -n "${EXISTING_ARN}" && "${EXISTING_ARN}" != "None" ]]; then
     DATA_AGENT_ARN="${EXISTING_ARN}"
     log_info "既存スタックからデータ分析エージェント設定を引き継ぎ: ${DATA_AGENT_ARN}"
-    sed -i "s|dataAgentRuntimeArn: ''|dataAgentRuntimeArn: '${DATA_AGENT_ARN}'|" "${PROJECT_ROOT}/cdk/parameters.ts"
+    sed_inplace "s|dataAgentRuntimeArn: ''|dataAgentRuntimeArn: '${DATA_AGENT_ARN}'|" "${PROJECT_ROOT}/cdk/parameters.ts"
   fi
 fi
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -50,12 +50,13 @@ log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 log_step()  { echo -e "\n${BLUE}========================================${NC}"; echo -e "${BLUE}  $1${NC}"; echo -e "${BLUE}========================================${NC}"; }
 
 # sedのインプレース編集（GNU sed / BSD sed 両対応）
-# macOSのBSD sedでは -i にバックアップ拡張子の引数が必須なため、OSによって呼び分ける
+# BSD sed（macOS、FreeBSD等）では -i にバックアップ拡張子の引数が必須なため、
+# OSではなくsedの実装を判定して呼び分ける（--versionはGNU sedのみ成功する）
 sed_inplace() {
-  if [[ "$(uname)" == "Darwin" ]]; then
-    sed -i '' "$@"
-  else
+  if sed --version > /dev/null 2>&1; then
     sed -i "$@"
+  else
+    sed -i '' "$@"
   fi
 }
 


### PR DESCRIPTION
## 概要

Fixes #134

macOS 上で `deploy.sh` を実行すると、BSD sed の `-i` オプション非互換により `unterminated transform target string` エラーでデプロイが途中中断される問題を修正します。

## 変更内容

- GNU sed（Linux）/ BSD sed（macOS）の両方に対応した `sed_inplace()` ヘルパー関数を追加
- deploy.sh 内の全13箇所の `sed -i` 呼び出しを `sed_inplace` に置き換え

## 動作確認

macOS（BSD sed）環境で以下を確認済み:

1. `bash -n deploy.sh` による構文チェック: OK
2. `sed_inplace` 単体テスト（`y` を含むパスの parameters.ts に対する置換）: OK
3. **`./deploy.sh --region ap-northeast-1` のフルデプロイを実行し、最後まで完走することを確認**
   - 従来の失敗地点（Step 6: Memory ID の parameters.ts 書き込み）を通過
   - Step 7（Cognito）、Step 8（メインスタック）を含む全ステップが成功し「デプロイ完了」まで到達
   - デプロイされたアプリ URL が Cognito ログインへの 302 リダイレクトを返すことを確認

CloudShell（Linux / GNU sed）では `uname` 判定により従来と同一の `sed -i` が実行されるため、既存の動作に影響はありません。
